### PR TITLE
Update viz tools

### DIFF
--- a/segmentation_labeling_app/transforms/array_utils.py
+++ b/segmentation_labeling_app/transforms/array_utils.py
@@ -5,6 +5,45 @@ import numpy as np
 from scipy.sparse import coo_matrix
 
 
+def content_boundary_2d(arr: Union[np.ndarray, coo_matrix]) -> np.ndarray:
+    """
+    Get the minimal row/column boundaries for content in a 2d array.
+
+    Parameters
+    ==========
+    arr: A 2d np.ndarray or coo_matrix. Other formats are also possible
+        (csc_matrix, etc.) as long as they have the toarray() method to
+         convert them to np.ndarray.
+
+    Returns
+    =======
+    4-tuple of row/column boundaries that define the minimal rectangle
+    around nonzero array content. Note that the maximum side boundaries
+    follow python indexing rules, so the value returned is the actual
+    max index + 1:
+        top_bound: smallest row index
+        bot_bound: largest row index + 1
+        left_bound: smallest column index
+        right_bound: largest column index + 1
+    """
+    if isinstance(arr, coo_matrix):
+        col = arr.col
+        row = arr.row
+    else:
+        if not isinstance(arr, np.ndarray):
+            arr = arr.toarray()
+        row, col = np.nonzero(arr)
+    if not row.size:
+        logging.warning("No content found. Either array is empty or all "
+                        "elements equal zero.")
+        return (0, 0, 0, 0)
+    left_bound = col.min()
+    right_bound = col.max() + 1
+    top_bound = row.min()
+    bot_bound = row.max() + 1
+    return top_bound, bot_bound, left_bound, right_bound
+
+
 def crop_2d_array(arr: Union[np.ndarray, coo_matrix]) -> np.ndarray:
     """
     Crop a 2d array to a rectangle surrounding all nonzero elements.
@@ -19,21 +58,13 @@ def crop_2d_array(arr: Union[np.ndarray, coo_matrix]) -> np.ndarray:
     ======
     ValueError if all elements are nonzero.
     """
-    if isinstance(arr, coo_matrix):
-        col = arr.col
-        row = arr.row
+    boundaries = content_boundary_2d(arr)
+    if not isinstance(arr, np.ndarray):
         arr = arr.toarray()
-    else:
-        if not isinstance(arr, np.ndarray):
-            arr = arr.toarray()
-        row, col = np.nonzero(arr)
-    if not row.size:
+    if sum(boundaries) == 0:
         raise ValueError("Cannot crop an empty array, or an array where all "
                          "elements are zero.")
-    left_bound = col.min()
-    right_bound = col.max() + 1
-    top_bound = row.min()
-    bot_bound = row.max() + 1
+    top_bound, bot_bound, left_bound, right_bound = boundaries
     return arr[top_bound:bot_bound, left_bound:right_bound]
 
 

--- a/segmentation_labeling_app/transforms/array_utils.py
+++ b/segmentation_labeling_app/transforms/array_utils.py
@@ -69,7 +69,8 @@ def crop_2d_array(arr: Union[np.ndarray, coo_matrix]) -> np.ndarray:
 
 
 def center_pad_2d(arr: np.ndarray, shape: Tuple[int, int],
-                  value: Type[np.dtype] = 0) -> np.ndarray:
+                  value: Type[np.dtype] = 0,
+                  allow_overflow: bool = True) -> np.ndarray:
     """
     Add padding around a numpy array such that the original array data
     stays in the center. If padding cannot be evenly applied due to the
@@ -85,6 +86,9 @@ def center_pad_2d(arr: np.ndarray, shape: Tuple[int, int],
         without any changes.
     value: (inherit from np.dtype) Any valid numpy dtype value. Should
         be homogenous with the input array.
+    allow_overflow: (bool) If true, will return array unchanged if the
+        array size is larger than the value for `shape`. If false,
+        will return None instead.
     """
     if arr.size == 0:
         return np.full(shape, value)
@@ -95,7 +99,10 @@ def center_pad_2d(arr: np.ndarray, shape: Tuple[int, int],
     if (img_size[0] > shape[0]) or (img_size[1] > shape[1]):
         logging.warning("Specified shape after padding is too small. "
                         "Returning input array without padding.")
-        return arr
+        if allow_overflow:
+            return arr
+        else:
+            return None
 
     if vertical_pad % 2 == 0:
         top_pad = bottom_pad = int(vertical_pad / 2)

--- a/tests/transforms/test_array_utils.py
+++ b/tests/transforms/test_array_utils.py
@@ -86,12 +86,13 @@ def test_crop_array_raises_error(arr):
 
 
 @pytest.mark.parametrize(
-    "arr,shape,value,expected",
+    "arr,shape,value,allow_overflow,expected",
     [
         (   # Can perfectly center, unit value
             np.array([[1]]),
             (3, 3),
             99,
+            True,
             np.array([[99, 99, 99],
                       [99, 1, 99],
                       [99, 99, 99]]),
@@ -100,6 +101,7 @@ def test_crop_array_raises_error(arr):
             np.array([[1], [2]]),
             (3, 4),
             0,
+            True,
             np.array([[0, 1, 0, 0],
                       [0, 2, 0, 0],
                       [0, 0, 0, 0]]),
@@ -108,10 +110,25 @@ def test_crop_array_raises_error(arr):
             np.zeros((0, 0)),
             (4, 4),
             1,
+            True,
             np.ones((4, 4)),
         ),
+        (   # Too big, let it go
+            np.ones((5, 5)),
+            (4, 4),
+            0,
+            True,
+            np.ones((5, 5))
+        ),
+        (   # Too big, no-go
+            np.ones((5, 5)),
+            (4, 4),
+            0,
+            False,
+            None
+        )
     ]
 )
-def test_center_pad_2d(arr, shape, value, expected):
-    np.testing.assert_array_equal(expected,
-                                  au.center_pad_2d(arr, shape, value))
+def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
+    np.testing.assert_equal(
+        expected, au.center_pad_2d(arr, shape, value, allow_overflow))

--- a/tests/transforms/test_array_utils.py
+++ b/tests/transforms/test_array_utils.py
@@ -8,6 +8,37 @@ from segmentation_labeling_app.transforms import array_utils as au
 @pytest.mark.parametrize(
     "arr,expected",
     [
+        (   # Typical
+            coo_matrix(
+                (np.array([3, 2, 1]),
+                 (np.array([0, 1, 0]), np.array([0, 1, 2]))),
+                shape=(4, 4)),
+            (0, 2, 0, 3)
+        ),
+        (   # Full data
+            np.ones((10, 10)),
+            (0, 10, 0, 10),
+        ),
+        (   # No data
+            np.zeros((5, 5)),
+            (0, 0, 0, 0),
+        ),
+        (   # Corners
+            coo_matrix(
+                (np.array([9, 9]),
+                 (np.array([0, 6]), np.array([0, 6]))),
+                shape=(7, 7)),
+            (0, 7, 0, 7)
+        ),
+    ]
+)
+def test_content_boundary_2d(arr, expected):
+    assert expected == au.content_boundary_2d(arr)
+
+
+@pytest.mark.parametrize(
+    "arr,expected",
+    [
         (
             coo_matrix(
                 (np.array([3, 2, 1]),


### PR DESCRIPTION
Some QOL updates for the ROI visualizations.

Get the content boundary as a separate function (so also can apply these boundaries to the source data)
Add option for the padding function to return None if it won't fit in the padded size (rather than logging a warning and returning original array). Good for filtering the large artifacts out