### PR TITLE
Feature/roi refactor

### DIFF
--- a/segmentation_labeling_app/rois/rois.py
+++ b/segmentation_labeling_app/rois/rois.py
@@ -57,38 +57,37 @@ class ROI:
                                       shape=image_shape)
 
     @classmethod
-    def roi_from_query(cls, segmentation_run_id: int,
-                       roi_id: int) -> "ROI":
+    def roi_from_query(cls, roi_id: int) -> "ROI":
         """
         Queries and builds ROI object by querying LIMS table for
         produced labeling ROIs.
         Args:
-            segmentation_run_id: Id of the segmentation run
             roi_id: Unique Id of the ROI to be loaded
 
         Returns: ROI object for the given segmentation_id and roi_id
         """
         label_vars = query_utils.get_labeling_env_vars()
 
-        segmentation_run = query_utils.query(
-            f"SELECT * FROM public.segmentation_runs WHERE id={segmentation_run_id}",
+        roi = query_utils.query(
+            f"SELECT * FROM rois WHERE id={roi_id}",
             user=label_vars.user,
             host=label_vars.host,
             database=label_vars.database,
             port=label_vars.port,
             password=label_vars.password)[0]
 
-        roi = query_utils.query(
-            f"SELECT * FROM public.rois WHERE "
-            f"segmentation_run_id={segmentation_run_id} AND id={roi_id}",
+        segmentation_run = query_utils.query(
+            ("SELECT * FROM segmentation_runs WHERE "
+             f"id={roi['segmentation_run_id']}"),
             user=label_vars.user,
             host=label_vars.host,
             database=label_vars.database,
             port=label_vars.port,
-            password=label_vars.password)
-        return ROI(coo_rows=roi[0]['coo_row'],
-                   coo_cols=roi[0]['coo_col'],
-                   coo_data=roi[0]['coo_data'],
+            password=label_vars.password)[0]
+
+        return ROI(coo_rows=roi['coo_row'],
+                   coo_cols=roi['coo_col'],
+                   coo_data=roi['coo_data'],
                    image_shape=segmentation_run['video_shape'],
                    experiment_id=segmentation_run['ophys_experiment_id'],
                    roi_id=roi_id)

--- a/segmentation_labeling_app/rois/rois.py
+++ b/segmentation_labeling_app/rois/rois.py
@@ -29,7 +29,7 @@ sql_insert_roi = """ INSERT INTO rois_prelabeling (transform_hash,
                      VALUES (?, ?, ?, ?, ?, ?, ?) """
 
 
-def cumulative_fraction_threshold(data, target_fraction, nbins=200):
+def cumulative_fraction_threshold(data, target_fraction):
     """return a threshold value above which the summed weights are
     target_fraction of the total summed weights
 
@@ -59,8 +59,7 @@ def cumulative_fraction_threshold(data, target_fraction, nbins=200):
 def binary_mask_from_threshold(
             arr: Union[np.ndarray, coo_matrix],
             absolute_threshold: float = None,
-            cumulative_threshold: float = 0.9,
-            nbins: int = 50) -> np.array:
+            cumulative_threshold: float = 0.9) -> np.array:
     """Binarize an array
 
     Parameters
@@ -73,9 +72,6 @@ def binary_mask_from_threshold(
     cumulative_threshold: float
         if specified, set absolute threshold determined by fraction of
         total weight above this value
-    nbins: int
-        if cumulative specified, determines
-        for interpolating
 
     Returns
     -------
@@ -91,8 +87,7 @@ def binary_mask_from_threshold(
     if cumulative_threshold is not None:
         absolute_threshold = cumulative_fraction_threshold(
                 vals,
-                cumulative_threshold,
-                nbins=nbins)
+                cumulative_threshold)
 
     binary = np.uint8(wmask > absolute_threshold)
 
@@ -220,7 +215,7 @@ class ROI:
             self, shape: Tuple[int, int] = None,
             full: bool = False,
             absolute_threshold: float = None,
-            cumulative_threshold: float = 0.9, nbins: int = 50,
+            cumulative_threshold: float = 0.9,
             dilation_kernel_size: int = 1, inner_outline: bool = True):
         """return a 2D dense representation of the mask outline
 
@@ -236,9 +231,6 @@ class ROI:
         cumulative_threshold: float
             if specified, set absolute threshold determined by fraction of
             total weight above this value
-        nbins: int
-            if cumulative specified, determines
-            for interpolating
         dilation_kernel_size: int
             passed as size to cv2.getStructuringElement()
         inner_outline: bool
@@ -253,8 +245,7 @@ class ROI:
         binary = binary_mask_from_threshold(
             self._sparse_coo,
             absolute_threshold=absolute_threshold,
-            cumulative_threshold=cumulative_threshold,
-            nbins=nbins)
+            cumulative_threshold=cumulative_threshold)
 
         contours, _ = cv2.findContours(binary,
                                        cv2.RETR_LIST,

--- a/tests/test_rois.py
+++ b/tests/test_rois.py
@@ -198,6 +198,7 @@ def test_roi_generate_mask(mask, shape, full, expected):
         ("weighted", "expected", "athresh", "quantile", "full"),
         [
             (
+                # basic test of making an outline mask
                 np.array([
                     [0.0, 0.0, 0.0, 0.0, 0.0],
                     [0.0, 0.5, 1.0, 0.0, 0.0],
@@ -216,6 +217,8 @@ def test_roi_generate_mask(mask, shape, full, expected):
                 None,
                 True),
             (
+                # basic test where the ROI produces two distinct
+                # contours in the outline mask
                 np.array([
                     [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
                     [1.0, 0.0, 0.5, 0.0, 0.0, 1.0],

--- a/tests/test_rois.py
+++ b/tests/test_rois.py
@@ -59,7 +59,6 @@ def test_binary_mask_from_threshold(
             weighted,
             absolute_threshold=athresh,
             cumulative_threshold=cthresh)
-    print(binary)
     assert np.all(binary == expected)
 
 

--- a/tests/test_rois.py
+++ b/tests/test_rois.py
@@ -214,7 +214,28 @@ def test_roi_generate_mask(mask, shape, full, expected):
                     ]),
                 0.7,
                 None,
-                True)])
+                True),
+            (
+                np.array([
+                    [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                    [1.0, 0.0, 0.5, 0.0, 0.0, 1.0],
+                    [1.0, 0.0, 2.0, 1.0, 0.5, 1.0],
+                    [2.0, 0.0, 1.0, 1.5, 0.5, 1.0],
+                    [1.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+                    [1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+                    ]),
+                np.array([
+                    [1, 1, 1, 1, 1, 1],
+                    [1, 0, 0, 0, 0, 1],
+                    [1, 0, 1, 1, 0, 1],
+                    [1, 0, 1, 1, 0, 1],
+                    [1, 0, 0, 0, 0, 1],
+                    [1, 1, 1, 1, 1, 1]
+                    ]),
+                0.7,
+                None,
+                True),
+            ])
 def test_roi_generate_outline(weighted, full, expected, athresh, quantile):
     """this test is not exhaustive
     """

--- a/tests/test_rois.py
+++ b/tests/test_rois.py
@@ -29,6 +29,8 @@ def test_cumulative_fraction(data, target_fraction, expected):
         ("weighted", "expected", "athresh", "cthresh"),
         [
             (
+                # cumulative threshold of 0.8 will
+                # eliminate the 0.5's in this example
                 np.array([
                     [0.0, 0.5, 1.0],
                     [0.0, 2.0, 2.0],
@@ -40,6 +42,8 @@ def test_cumulative_fraction(data, target_fraction, expected):
                 None,
                 0.8),
             (
+                # absolute threshold will only keep
+                # values > 1.5
                 np.array([
                     [0.0, 0.5, 1.0],
                     [0.0, 2.0, 2.0],
@@ -130,6 +134,8 @@ def test_sized_mask(mask, full, shape, expected, use_coo):
 
 @pytest.mark.parametrize("mask, full, shape, expected", [
     (
+        # full=False and shape=None will just
+        # crop to the data
         np.array([
             [0.0, 0.0, 0.0, 0.0],
             [0.0, 1.0, 1.0, 0.0],
@@ -141,6 +147,8 @@ def test_sized_mask(mask, full, shape, expected, use_coo):
             [1.0, 1.0],
             [1.0, 1.0]])),
     (
+        # full = True will give back the entire frame
+        # in this case, the frame is only 4x4
         np.array([
             [0.0, 0.0, 0.0, 0.0],
             [0.0, 1.0, 1.0, 0.0],
@@ -155,6 +163,9 @@ def test_sized_mask(mask, full, shape, expected, use_coo):
             [0.0, 0.0, 0.0, 0.0]]),
         ),
     (
+        # shape=(5, 5) should give back a
+        # padded window of that shape
+        # this is an asymmetric padding case
         np.array([
             [0.0, 0.0, 0.0, 0.0],
             [0.0, 1.0, 1.0, 0.0],
@@ -170,6 +181,8 @@ def test_sized_mask(mask, full, shape, expected, use_coo):
             [0.0, 0.0, 0.0, 0.0, 0.0]]),
         ),
     (
+        # shape=(6, 6) also should come back
+        # this is a symmetric padding case
         np.array([
             [0.0, 0.0, 0.0, 0.0],
             [0.0, 1.0, 1.0, 0.0],

--- a/tests/test_rois.py
+++ b/tests/test_rois.py
@@ -1,209 +1,239 @@
 import json
-
 import sqlite3
 import pytest
 import numpy as np
-
+from scipy.sparse import coo_matrix
 import segmentation_labeling_app.rois.rois as roi_module
 
 
-@pytest.mark.parametrize(("coo_rows, coo_cols, coo_data, video_shape,"
-                          "segmentation_id, roi_id, threshold, expected_mask"), [
-    ([0, 0, 1, 1], [0, 1, 0, 1],
-     [0.75, 0.8, 0.9, 0.85], (3, 3), 1, 1, 0.7,
-     np.array([[1, 1, 0], [1, 1, 0], [0, 0, 0]])),
-    ([0, 0, 0, 1, 1, 1], [0, 1, 2, 0, 1, 2],
-     [0.75, 0.8, 0.5, 0.9, 0.85, 0.4], (3, 3), 1, 1, 0.7,
-     np.array([[1, 1, 0], [1, 1, 0], [0, 0, 0]]))
-])
-def test_binary_mask(coo_rows, coo_cols, coo_data, video_shape,
-                     segmentation_id, roi_id, threshold, expected_mask):
-    test_roi = roi_module.ROI(coo_rows, coo_cols, coo_data,
-                              video_shape, segmentation_id, roi_id)
-    generated_mask = test_roi.generate_binary_mask_from_threshold(threshold=threshold)
-    assert np.array_equal(generated_mask, expected_mask)
+@pytest.mark.parametrize(
+        ("data", "target_fraction", "expected"),
+        [
+            (np.linspace(0, 1.0, 1000), 0.95, 0.95),
+            (np.linspace(0, 1.0, 1000), 0.05, 0.05),
+            (np.array([1.0, 1.0, 5.0, 5.0]), 0.65, 10/12)
+            ])
+def test_cumulative_fraction(data, target_fraction, expected):
+    """for large number of samples, we get close to what is expected
+    for small numbers of samples, the possible fractional values
+    are not as close to a continuous function.
+    """
+    absolute_threshold = roi_module.cumulative_fraction_threshold(
+            data, target_fraction)
+    frac = data[data > absolute_threshold].sum() / data.sum()
+    assert np.isclose(frac, expected, atol=0.05)
 
 
-@pytest.mark.parametrize(("coo_rows, coo_cols, coo_data, video_shape,"
-                          "segmentation_id, roi_id, threshold, expected_edges"),
-                         [([1, 1, 1, 2, 2, 2, 3, 3, 3],
-                           [1, 2, 3, 1, 2, 3, 1, 2, 3],
-                           [0.8, 0.9, 0.85, 0.75, 0.8, 0.82, 0.9, 0.85, 1],
-                           (5, 5), 1, 1, 0.7, np.array([[1, 1], [1, 2],
-                                                        [1, 3], [2, 1],
-                                                        [2, 3], [3, 1],
-                                                        [3, 2], [3, 3]])),
-                          ([1, 1, 1, 2, 2, 2, 2, 3, 3, 3],
-                           [1, 2, 3, 0, 1, 2, 3, 1, 2, 3],
-                           [0.75, 0.8, 0.9, 0.85, 0.75, 0.8, 0.82, 0.9, 0.85, 1],
-                           (5, 5), 1, 1, 0.7, np.array([[0, 2], [1, 1],
-                                                        [1, 3], [2, 1],
-                                                        [2, 3], [3, 1],
-                                                        [3, 2], [3, 3]])),
-                          ([1], [1], [0.75], (2, 2), 1, 1, 0.7,
-                           np.array([[1, 1]])),
-                          ([], [], [], (2, 2), 1, 1, 0.7,
-                           np.array([])),
-                          ([1, 1, 1, 2, 2, 3, 3, 3],
-                           [1, 2, 3, 1, 3, 1, 2, 3],
-                           [0.8, 0.9, 0.85, 0.75, 0.82, 0.9, 0.85, 1],
-                           (5, 5), 1, 1, 0.7, np.array([[1, 1], [1, 2],
-                                                        [1, 3], [2, 1],
-                                                        [2, 3],
-                                                        [3, 1], [3, 2],
-                                                        [3, 3]])),
-                          ([1, 1, 2, 2], [1, 2, 1, 2], [0.5, 0.5, 0.5, 0.5],
-                           (5, 5), 1, 1, 0.7, np.array([])),
-                          ([1, 1, 1, 2, 2, 2, 3, 3, 3],
-                           [1, 2, 3, 1, 2, 3, 1, 2, 3],
-                           [0.8, 0.9, 0.4, 0.75, 0.5, 0.82, 0.9, 0.85, 1],
-                           (5, 5), 1, 1, 0.7, np.array([[1, 1], [1, 2],
-                                                        [1, 3], [2, 1],
-                                                        [2, 3],
-                                                        [3, 2], [3, 3]])),
-                          ([0, 0, 1, 1, 2, 2, 3, 3], [0, 1, 0, 1, 2, 3, 2, 3],
-                           [0.8, 0.9, 0.85, 0.75, 0.75, 0.84, 0.9, 0.87],
-                           (4, 4), 1, 1, 0.7, np.array([[0, 0], [0, 1],
-                                                        [1, 0], [1, 1],
-                                                        [2, 2], [2, 3],
-                                                        [3, 2], [3, 3]]))])
-def test_edge_detection_edges(coo_rows, coo_cols, coo_data, video_shape,
-                              segmentation_id, roi_id, threshold,
-                              expected_edges):
-    """
-    Test Cases:
-        1) 3 x 3 object in 5 x 5 video
-        2) 3 x 3 object with out cropping in 5 x 5 video
-        3) 1 x 1 object in 5 x 5 video
-        4) 0 x 0 object in 5 x 5 video
-        5) 3 x 3 object with a hole in center in a 5 x 5 box
-        6) 2 x 2 object with all values below threshold in a 5 x 5 box
-        7) 3 x 3 object with one pixel below threshold in 5 x 5 box
-        8) 2 x 2 object in top left corner and 2 x 2 in bottom right corner
-           not touching each other in a 4 x 4 box
-    """
-    test_roi = roi_module.ROI(coo_rows, coo_cols, coo_data,
-                              video_shape, segmentation_id, roi_id)
-    edge_points = test_roi.get_edge_points(threshold=threshold)
-    assert np.array_equal(expected_edges, edge_points)
+@pytest.mark.parametrize("use_coo", [True, False])
+@pytest.mark.parametrize(
+        ("weighted", "expected", "athresh", "cthresh"),
+        [
+            (
+                np.array([
+                    [0.0, 0.5, 1.0],
+                    [0.0, 2.0, 2.0],
+                    [2.0, 1.0, 0.5]]),
+                np.array([
+                    [0, 0, 1],
+                    [0, 1, 1],
+                    [1, 1, 0]]),
+                None,
+                0.8),
+            (
+                np.array([
+                    [0.0, 0.5, 1.0],
+                    [0.0, 2.0, 2.0],
+                    [2.0, 1.0, 0.5]]),
+                np.array([
+                    [0, 0, 0],
+                    [0, 1, 1],
+                    [1, 0, 0]]),
+                1.5,
+                None),
+                ])
+def test_binary_mask_from_threshold(
+        weighted, expected, athresh, cthresh, use_coo):
+    if use_coo:
+        weighted = coo_matrix(weighted)
+    binary = roi_module.binary_mask_from_threshold(
+            weighted,
+            absolute_threshold=athresh,
+            cumulative_threshold=cthresh)
+    print(binary)
+    assert np.all(binary == expected)
 
 
-@pytest.mark.parametrize(("coo_rows, coo_cols, coo_data, video_shape,"
-                          "segmentation_id, roi_id, threshold, expected_mask"),
-                         [([1, 1, 1, 2, 2, 2, 3, 3, 3],
-                           [1, 2, 3, 1, 2, 3, 1, 2, 3],
-                           [0.8, 0.9, 0.85, 0.75, 0.8, 0.82, 0.9, 0.85, 1],
-                           (5, 5), 1, 1, 0.7, np.array([[0, 0, 0, 0, 0],
-                                                        [0, 1, 1, 1, 0],
-                                                        [0, 1, 0, 1, 0],
-                                                        [0, 1, 1, 1, 0],
-                                                        [0, 0, 0, 0, 0]])),
-                          ([1, 1, 1, 2, 2, 2, 2, 3, 3, 3],
-                           [1, 2, 3, 0, 1, 2, 3, 1, 2, 3],
-                           [0.75, 0.8, 0.9, 0.85, 0.75, 0.8, 0.82, 0.9, 0.85, 1],
-                           (5, 5), 1, 1, 0.7, np.array([[0, 0, 0, 0, 0],
-                                                        [0, 1, 1, 1, 0],
-                                                        [1, 0, 0, 1, 0],
-                                                        [0, 1, 1, 1, 0],
-                                                        [0, 0, 0, 0, 0]])),
-                          ([], [], [], (5, 5), 1, 1, 0.7, np.array([[0, 0, 0, 0, 0],
-                                                                    [0, 0, 0, 0, 0],
-                                                                    [0, 0, 0, 0, 0],
-                                                                    [0, 0, 0, 0, 0],
-                                                                    [0, 0, 0, 0, 0]])),
-                          ([1], [1], [1], (3, 3), 1, 1, 0.75, np.array([[0, 0, 0],
-                                                                        [0, 1, 0],
-                                                                        [0, 0, 0]]))])
-def test_edge_detection_mask(coo_rows, coo_cols, coo_data, video_shape,
-                             segmentation_id, roi_id, threshold,
-                             expected_mask):
-    """
-    Test Case:
-        1) 3 x 3 object in 5 x 5 in frame, edge mask gets rid of center
-        2) 3 x 3 object with overhang at (2, 0) in a 5 x 5 frame, edge mask eliminates pixels (2, 1) at (2, 2)
-        3) 0 x 0 object in a 5 x 5 frame, edge mask gets nothing
-        4) 1 x 1 object in a 5 x 5 frame, edge mask return 1 x 1 object
-    """
-    test_roi = roi_module.ROI(coo_rows, coo_cols, coo_data,
-                              video_shape, segmentation_id, roi_id)
-    edge_mask = test_roi.get_edge_mask(threshold=threshold)
-    assert np.array_equal(expected_mask, edge_mask)
+@pytest.mark.parametrize("use_coo", [True, False])
+@pytest.mark.parametrize("mask, full, shape, expected", [
+    (
+        np.array([
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0]]),
+        False,
+        None,
+        np.array([
+            [1.0, 1.0],
+            [1.0, 1.0]])),
+    (
+        np.array([
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0]]),
+        True,
+        None,
+        np.array([
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0]]),
+        ),
+    (
+        np.array([
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0]]),
+        False,
+        (5, 5),
+        np.array([
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0]]),
+        ),
+    (
+        np.array([
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0]]),
+        False,
+        (6, 6),
+        np.array([
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]),
+        ),
+    ])
+def test_sized_mask(mask, full, shape, expected, use_coo):
+    if use_coo:
+        mask = coo_matrix(mask)
+    sized = roi_module.sized_mask(mask, shape=shape, full=full)
+    assert np.all(sized == expected)
 
 
-@pytest.mark.parametrize(("coo_rows, coo_cols, coo_data, video_shape,"
-                          "segmentation_id, roi_id, threshold, stroke_size,"
-                          "expected_mask"),
-                         [([1, 1, 1, 2, 2, 2, 3, 3, 3],
-                           [1, 2, 3, 1, 2, 3, 1, 2, 3],
-                           [0.8, 0.9, 0.85, 0.75, 0.8, 0.82, 0.9, 0.85, 1],
-                           (5, 5), 1, 1, 0.7, 1, np.array([[0, 0, 0, 0, 0],
-                                                          [0, 1, 1, 1, 0],
-                                                          [0, 1, 0, 1, 0],
-                                                          [0, 1, 1, 1, 0],
-                                                          [0, 0, 0, 0, 0]])),
-                          ([1, 1, 1, 2, 2, 2, 2, 3, 3, 3],
-                           [1, 2, 3, 0, 1, 2, 3, 1, 2, 3],
-                           [0.75, 0.8, 0.9, 0.85, 0.75, 0.8, 0.82, 0.9, 0.85, 1],
-                           (5, 5), 1, 1, 0.7, 1, np.array([[0, 0, 0, 0, 0],
-                                                          [0, 1, 1, 1, 0],
-                                                          [1, 0, 0, 1, 0],
-                                                          [0, 1, 1, 1, 0],
-                                                          [0, 0, 0, 0, 0]])),
-                          ([2, 2, 3, 3], [2, 3, 2, 3], [0.85, 0.9, 0.89, 0.72],
-                           (5, 5), 1, 1, 0.7, 2, np.array([[0, 0, 0, 0, 0],
-                                                           [0, 1, 1, 1, 1],
-                                                           [0, 1, 1, 1, 1],
-                                                           [0, 1, 1, 1, 1],
-                                                           [0, 1, 1, 1, 1]])),
-                          ([2, 2, 2, 3, 3, 4, 4, 4],
-                           [2, 3, 4, 2, 4, 2, 3, 4],
-                           [1, 1, 1, 1, 1, 1, 1, 1],
-                           (7, 7), 1, 1, 0.7, 2, np.array(
-                              [[0, 0, 0, 0, 0, 0, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 1, 1, 0, 1, 1, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 1, 1, 1, 1, 1, 0],
-                               [0, 0, 0, 0, 0, 0, 0]]
-                          )),
-                          ([], [], [], (3, 3), 1, 1, 0.7, 3,
-                           np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0]])),
-                          ([1], [1], [1], (3, 3), 1, 1, 0.7, 2,
-                           np.array([[1, 1, 1], [1, 1, 1], [1, 1, 1]])),
-                          ([0, 0, 1, 1, 3, 3, 4, 4], [0, 1, 0, 1, 3, 4, 3, 4],
-                           [1, 1, 1, 1, 1, 1, 1, 1], (5, 5), 1, 1, 0.5, 2,
-                           np.array([[1, 1, 1, 0, 0], [1, 1, 1, 0, 0],
-                                     [1, 1, 0, 1, 1], [0, 0, 1, 1, 1],
-                                     [0, 0, 1, 1, 1]])),
-                          ([1, 1, 1, 2, 2, 2, 3, 3, 3],
-                           [1, 2, 3, 1, 2, 3, 1, 2, 3],
-                           [0.75, 0.89, 0.92, 1, 0.43, 0.56, 0.98, 0.3, 0.1],
-                           (5, 5), 1, 1, 0.5, 2, np.array([[1, 1, 1, 1, 1],
-                                                           [1, 1, 1, 1, 1],
-                                                           [1, 1, 0, 1, 1],
-                                                           [1, 1, 0, 1, 1],
-                                                           [1, 1, 1, 0, 0]]))
-                          ])
-def test_edge_dilated_mask(coo_rows, coo_cols, coo_data, video_shape,
-                           segmentation_id, roi_id, threshold, stroke_size,
-                           expected_mask):
+@pytest.mark.parametrize("mask, full, shape, expected", [
+    (
+        np.array([
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0]]),
+        False,
+        None,
+        np.array([
+            [1.0, 1.0],
+            [1.0, 1.0]])),
+    (
+        np.array([
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0]]),
+        True,
+        None,
+        np.array([
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0]]),
+        ),
+    (
+        np.array([
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0]]),
+        False,
+        (5, 5),
+        np.array([
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0]]),
+        ),
+    (
+        np.array([
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 1.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0]]),
+        False,
+        (6, 6),
+        np.array([
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]]),
+        ),
+    ])
+def test_roi_generate_mask(mask, shape, full, expected):
+    coo = coo_matrix(mask)
+    roi = roi_module.ROI(
+            coo.row,
+            coo.col,
+            coo.data,
+            image_shape=(4, 4),
+            experiment_id=1234,
+            roi_id=4567)
+    roi_mask = roi.generate_ROI_mask(shape=shape, full=full)
+    assert np.all(roi_mask == expected)
+
+
+@pytest.mark.parametrize(
+        ("weighted", "expected", "athresh", "cthresh", "full"),
+        [
+            (
+                np.array([
+                    [0.0, 0.0, 0.0, 0.0, 0.0],
+                    [0.0, 0.5, 1.0, 0.0, 0.0],
+                    [0.0, 2.0, 2.0, 1.5, 0.0],
+                    [2.0, 1.0, 1.5, 0.5, 0.0],
+                    [0.0, 0.0, 0.0, 0.0, 0.0]
+                    ]),
+                np.array([
+                    [0, 0, 0, 0, 0],
+                    [0, 0, 1, 0, 0],
+                    [0, 1, 0, 1, 0],
+                    [1, 1, 1, 0, 0],
+                    [0, 0, 0, 0, 0]
+                    ]),
+                0.7,
+                None,
+                True)])
+def test_roi_generate_outline(weighted, full, expected, athresh, cthresh):
+    """this test is not exhaustive
     """
-    Test Cases:
-        1) 3 x 3 object, dilated once to removes middle
-        2) 3 x 3 object with overhang at row 2 col 0, dilated once removes all but edges
-        3) 2 x 2 object centered in the bottom right quadrant, dilated once doubles width and height
-        4) 3 x 3 object centered in the middle of frame with hole at center, dilated twice
-        5) 0 x 0 object, dilated three times maintains no valid pixels
-        6) 1 x 1 object in 3 x 3 frame, dilated twice to fill frame
-        7) Two 2 x 2 objects in 5 x 5 frame, disjoint and not touching, dilated once
-        8) 3 x 3 object with certain pixels below threshold, dilated twice
-    """
-    test_roi = roi_module.ROI(coo_rows, coo_cols, coo_data,
-                              video_shape, segmentation_id, roi_id)
-    dilated_mask = test_roi.create_dilated_contour_mask(threshold=threshold,
-                                                        stroke_size=stroke_size)
-    assert np.array_equal(expected_mask, dilated_mask)
+    coo = coo_matrix(weighted)
+    roi = roi_module.ROI(
+            coo.row,
+            coo.col,
+            coo.data,
+            image_shape=weighted.shape,
+            experiment_id=1234,
+            roi_id=4567)
+    outline = roi.generate_ROI_outline(full=full)
+    assert np.all(outline == expected)
 
 
 @pytest.mark.parametrize(("coo_rows, coo_cols, coo_data, video_shape,"
@@ -231,12 +261,13 @@ def test_roi_manifest_json(coo_rows, coo_cols, coo_data, video_shape,
                            roi_data_source_ref, expected_manifest):
     test_roi = roi_module.ROI(coo_rows, coo_cols, coo_data,
                               video_shape, segmentation_id, roi_id)
-    test_manifest = test_roi.create_manifest_json(source_ref=source_ref,
-                                                  video_source_ref=video_source_ref,
-                                                  max_source_ref=max_source_ref,
-                                                  avg_source_ref=avg_source_ref,
-                                                  trace_source_ref=trace_source_ref,
-                                                  roi_data_source_ref=roi_data_source_ref)
+    test_manifest = test_roi.create_manifest_json(
+            source_ref=source_ref,
+            video_source_ref=video_source_ref,
+            max_source_ref=max_source_ref,
+            avg_source_ref=avg_source_ref,
+            trace_source_ref=trace_source_ref,
+            roi_data_source_ref=roi_data_source_ref)
     assert test_manifest == expected_manifest
 
 
@@ -256,12 +287,13 @@ def test_roi_db_table_write(coo_rows, coo_cols, coo_data, video_shape,
                               video_shape, segmentation_id, roi_id)
     database_file = tmp_path / 'test_db.db'
 
-    _ = test_roi.write_roi_to_db(database_file,
-                                 transform_hash=transform_hash,
-                                 ophys_segmentation_commit_hash=ophys_segmentation_commit_hash,
-                                 creation_date=creation_date,
-                                 upload_date=upload_date,
-                                 manifest=manifest)
+    test_roi.write_roi_to_db(
+            database_file,
+            transform_hash=transform_hash,
+            ophys_segmentation_commit_hash=ophys_segmentation_commit_hash,
+            creation_date=creation_date,
+            upload_date=upload_date,
+            manifest=manifest)
 
     db_connection = sqlite3.connect(database_file.as_posix())
     curr = db_connection.cursor()


### PR DESCRIPTION
refactor motivation:
* was writing the transform pipeline and needed additional functionality. Kat had added some useful utility functions in `rois/array_utils`
* added more sophisticated quantile, in addition to absolute thresholding. This will be better because ROIs don't have a consistent weight range.
* wanted a clearer interface to the design-specified functionality for the ROI class.
* fixed some postgres query issues.

With these changes, sizing masks and outlines to be the same shape and center will be enabled easily, for example:
```
mask = roi.generate_ROI_mask(
    shape=self.args['cropped_shape'])
outline = roi.generate_ROI_outline(
    shape=self.args['cropped_shape'],
    cumulative_threshold=self.args['outline_threshold'])
```

Some of the mask and outline functionality demonstrated:
```
r = rois.ROI.roi_from_query(1972)
mask = r.generate_ROI_mask()
plt.imshow(mask)        
```
![image](https://user-images.githubusercontent.com/32312979/79938340-34996500-8411-11ea-8b31-706d5f1966ad.png)

```
mask = r.generate_ROI_mask(full=True)
plt.imshow(mask)        
```
![image](https://user-images.githubusercontent.com/32312979/79938392-585cab00-8411-11ea-8ebd-84c590bf6c1b.png)

```
mask = r.generate_ROI_mask(shape=(128, 128))
plt.imshow(mask)        
```
![image](https://user-images.githubusercontent.com/32312979/79938454-8346ff00-8411-11ea-99e2-76e71515a31e.png)

```
outline = r.generate_ROI_outline()
plt.imshow(outline, cmap='gray')
```
![image](https://user-images.githubusercontent.com/32312979/80037468-79bca600-84a8-11ea-8ca0-114c6409756b.png)

```
outline = r.generate_ROI_outline(full=True)
plt.imshow(outline, cmap='gray')
```
![image](https://user-images.githubusercontent.com/32312979/80037532-9822a180-84a8-11ea-8d2d-3daa3d505db7.png)

```
outline = r.generate_ROI_outline(shape=(128, 128))
plt.imshow(outline, cmap='gray')
```
![image](https://user-images.githubusercontent.com/32312979/80037571-acff3500-84a8-11ea-9d64-dd2026624059.png)


```
outline = r.generate_ROI_outline(
    shape=(128, 128),
    quantile=0.01,
    inner_outline=True,
    dilation_kernel_size=4)
plt.imshow(outline, cmap='gray')
```
![image](https://user-images.githubusercontent.com/32312979/80037625-ca340380-84a8-11ea-9cb2-09c42e65669d.png)
