### PR TITLE
Feature/update array utils

### DIFF
--- a/segmentation_labeling_app/transforms/array_utils.py
+++ b/segmentation_labeling_app/transforms/array_utils.py
@@ -59,7 +59,6 @@ def content_extents(
     shape: (Tuple[int,int]) Desired final shape after padding is applied.
         If smaller than the input array, will return the input array
         without any changes.
-<<<<<<< HEAD
     target_shape: (Tuple[int, int]) Extent of array to be indexed. If None
         padding will still handle top and left, but bottom and right padding
         will always be zero
@@ -70,12 +69,16 @@ def content_extents(
         4-tuple of row/column boundaries
     pad_width: tuple(tuple, tuple)
         to be passed into numpy.pad as pad_width
-=======
+    target_shape: (Tuple[int, int]) Extent of array to be indexed. If None
+        padding will still handle top and left, but bottom and right padding
+        will always be zero
 
     Returns
     -------
-    4-tuple of row/column boundaries. Can be negative.
->>>>>>> adds new extents capability for indexing video frames
+    indexing_bounds: tuple
+        4-tuple of row/column boundaries
+    pad_width: tuple(tuple, tuple)
+        to be passed into numpy.pad as pad_width
 
     """
     boundaries = content_boundary_2d(arr)
@@ -101,7 +104,6 @@ def content_extents(
     left = boundaries[2] - left_pad
     right = boundaries[3] + right_pad
 
-<<<<<<< HEAD
     pad_width = [[0, 0], [0, 0]]
     if top < 0:
         pad_width[0][0] = abs(top)
@@ -123,9 +125,6 @@ def content_extents(
     pad_width = tuple([tuple(i) for i in pad_width])
 
     return indexing_bounds, pad_width
-=======
-    return top, bot, left, right
->>>>>>> adds new extents capability for indexing video frames
 
 
 def crop_2d_array(arr: Union[np.ndarray, coo_matrix]) -> np.ndarray:

--- a/segmentation_labeling_app/transforms/array_utils.py
+++ b/segmentation_labeling_app/transforms/array_utils.py
@@ -44,6 +44,52 @@ def content_boundary_2d(arr: Union[np.ndarray, coo_matrix]) -> np.ndarray:
     return top_bound, bot_bound, left_bound, right_bound
 
 
+def content_extents(
+        arr: Union[np.ndarray, coo_matrix],
+        shape: Tuple[int, int]):
+    """return the bounding box of size shape. Intended to be applied to
+    a target data source, for example a set of video frames.
+
+    Parameters
+    ----------
+    arr: A 2d np.ndarray or coo_matrix. Other formats are also possible
+        (csc_matrix, etc.) as long as they have the toarray() method to
+         convert them to np.ndarray.
+    shape: (Tuple[int,int]) Desired final shape after padding is applied.
+        If smaller than the input array, will return the input array
+        without any changes.
+
+    Returns
+    -------
+    4-tuple of row/column boundaries. Can be negative.
+
+    """
+    boundaries = content_boundary_2d(arr)
+    height = boundaries[1] - boundaries[0]
+    width = boundaries[3] - boundaries[2]
+
+    vertical_pad = shape[0] - height
+    horizontal_pad = shape[1] - width
+
+    if vertical_pad % 2 == 0:
+        top_pad = bottom_pad = int(vertical_pad / 2)
+    else:
+        top_pad = math.floor(vertical_pad / 2)
+        bottom_pad = top_pad + 1
+    if horizontal_pad % 2 == 0:
+        left_pad = right_pad = int(horizontal_pad / 2)
+    else:
+        left_pad = math.floor(horizontal_pad / 2)
+        right_pad = left_pad + 1
+
+    top = boundaries[0] - top_pad
+    bot = boundaries[1] + bottom_pad
+    left = boundaries[2] - left_pad
+    right = boundaries[3] + right_pad
+
+    return top, bot, left, right
+
+
 def crop_2d_array(arr: Union[np.ndarray, coo_matrix]) -> np.ndarray:
     """
     Crop a 2d array to a rectangle surrounding all nonzero elements.

--- a/segmentation_labeling_app/transforms/array_utils.py
+++ b/segmentation_labeling_app/transforms/array_utils.py
@@ -59,6 +59,7 @@ def content_extents(
     shape: (Tuple[int,int]) Desired final shape after padding is applied.
         If smaller than the input array, will return the input array
         without any changes.
+<<<<<<< HEAD
     target_shape: (Tuple[int, int]) Extent of array to be indexed. If None
         padding will still handle top and left, but bottom and right padding
         will always be zero
@@ -69,6 +70,12 @@ def content_extents(
         4-tuple of row/column boundaries
     pad_width: tuple(tuple, tuple)
         to be passed into numpy.pad as pad_width
+=======
+
+    Returns
+    -------
+    4-tuple of row/column boundaries. Can be negative.
+>>>>>>> adds new extents capability for indexing video frames
 
     """
     boundaries = content_boundary_2d(arr)
@@ -94,6 +101,7 @@ def content_extents(
     left = boundaries[2] - left_pad
     right = boundaries[3] + right_pad
 
+<<<<<<< HEAD
     pad_width = [[0, 0], [0, 0]]
     if top < 0:
         pad_width[0][0] = abs(top)
@@ -115,6 +123,9 @@ def content_extents(
     pad_width = tuple([tuple(i) for i in pad_width])
 
     return indexing_bounds, pad_width
+=======
+    return top, bot, left, right
+>>>>>>> adds new extents capability for indexing video frames
 
 
 def crop_2d_array(arr: Union[np.ndarray, coo_matrix]) -> np.ndarray:

--- a/tests/transforms/test_array_utils.py
+++ b/tests/transforms/test_array_utils.py
@@ -147,7 +147,11 @@ def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
                     [0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0, 0, 0]]),
                 (5, 5),
+<<<<<<< HEAD
                 ((1, 6, 1, 6), ((0, 0), (0, 0)))),
+=======
+                (1, 6, 1, 6)),
+>>>>>>> adds new extents capability for indexing video frames
             (
                 np.array([
                     [0, 0, 0, 0, 0, 0, 0],
@@ -158,7 +162,11 @@ def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
                     [0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0, 0, 0]]),
                 (5, 5),
+<<<<<<< HEAD
                 ((1, 6, 1, 6), ((0, 0), (0, 0)))),
+=======
+                (1, 6, 1, 6)),
+>>>>>>> adds new extents capability for indexing video frames
             (
                 np.array([
                     [0, 0, 0, 0, 0, 0, 0],
@@ -169,7 +177,11 @@ def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
                     [0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0, 0, 0]]),
                 (5, 5),
+<<<<<<< HEAD
                 ((2, 7, 2, 7), ((0, 0), (0, 0)))),
+=======
+                (2, 7, 2, 7)),
+>>>>>>> adds new extents capability for indexing video frames
             (
                 np.array([
                     [1, 1, 0, 0, 0, 0, 0],
@@ -180,7 +192,11 @@ def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
                     [0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0, 0, 0]]),
                 (5, 5),
+<<<<<<< HEAD
                 ((0, 3, 0, 4), ((2, 0), (1, 0)))),
+=======
+                (-2, 3, -1, 4)),
+>>>>>>> adds new extents capability for indexing video frames
             (
                 np.array([
                     [0, 0, 0, 0, 0, 0, 0],
@@ -191,7 +207,11 @@ def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
                     [1, 1, 1, 1, 1, 1, 1],
                     [0, 0, 0, 0, 0, 0, 0]]),
                 (2, 2),
+<<<<<<< HEAD
                 ((3, 5, 3, 5), ((0, 0), (0, 0)))),
+=======
+                (3, 5, 3, 5)),
+>>>>>>> adds new extents capability for indexing video frames
             (
                 np.array([
                     [0, 0, 0, 0, 0, 0, 0],

--- a/tests/transforms/test_array_utils.py
+++ b/tests/transforms/test_array_utils.py
@@ -147,7 +147,7 @@ def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
                     [0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0, 0, 0]]),
                 (5, 5),
-                (1, 6, 1, 6)),
+                ((1, 6, 1, 6), ((0, 0), (0, 0)))),
             (
                 np.array([
                     [0, 0, 0, 0, 0, 0, 0],
@@ -158,7 +158,7 @@ def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
                     [0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0, 0, 0]]),
                 (5, 5),
-                (1, 6, 1, 6)),
+                ((1, 6, 1, 6), ((0, 0), (0, 0)))),
             (
                 np.array([
                     [0, 0, 0, 0, 0, 0, 0],
@@ -169,7 +169,7 @@ def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
                     [0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0, 0, 0]]),
                 (5, 5),
-                (2, 7, 2, 7)),
+                ((2, 7, 2, 7), ((0, 0), (0, 0)))),
             (
                 np.array([
                     [1, 1, 0, 0, 0, 0, 0],
@@ -180,7 +180,7 @@ def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
                     [0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0, 0, 0]]),
                 (5, 5),
-                (-2, 3, -1, 4)),
+                ((0, 3, 0, 4), ((2, 0), (1, 0)))),
             (
                 np.array([
                     [0, 0, 0, 0, 0, 0, 0],
@@ -191,7 +191,7 @@ def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
                     [1, 1, 1, 1, 1, 1, 1],
                     [0, 0, 0, 0, 0, 0, 0]]),
                 (2, 2),
-                (3, 5, 3, 5)),
+                ((3, 5, 3, 5), ((0, 0), (0, 0)))),
             (
                 np.array([
                     [0, 0, 0, 0, 0, 0, 0],
@@ -202,7 +202,7 @@ def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
                     [1, 1, 1, 1, 1, 1, 1],
                     [0, 0, 0, 0, 0, 0, 0]]),
                 (3, 3),
-                (2, 5, 2, 5)),
+                ((2, 5, 2, 5), ((0, 0), (0, 0)))),
             ])
 def test_content_extents(arr, shape, expected):
     bounds = au.content_extents(arr, shape)
@@ -229,6 +229,8 @@ def test_compare_crop_pad_and_extents(arr, shape):
     indexing the array (i.e. as would be applied to video frame)
     """
     cropped_padded = au.center_pad_2d(au.crop_2d_array(arr), shape)
-    extents = au.content_extents(arr, shape)
-    indexed = arr[extents[0]:extents[1], extents[2]:extents[3]]
+    extents, pad_width = au.content_extents(arr, shape)
+    indexed = np.pad(
+            arr[extents[0]:extents[1], extents[2]:extents[3]],
+            pad_width)
     assert np.all(cropped_padded == indexed)

--- a/tests/transforms/test_array_utils.py
+++ b/tests/transforms/test_array_utils.py
@@ -147,11 +147,7 @@ def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
                     [0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0, 0, 0]]),
                 (5, 5),
-<<<<<<< HEAD
                 ((1, 6, 1, 6), ((0, 0), (0, 0)))),
-=======
-                (1, 6, 1, 6)),
->>>>>>> adds new extents capability for indexing video frames
             (
                 np.array([
                     [0, 0, 0, 0, 0, 0, 0],
@@ -162,11 +158,7 @@ def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
                     [0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0, 0, 0]]),
                 (5, 5),
-<<<<<<< HEAD
                 ((1, 6, 1, 6), ((0, 0), (0, 0)))),
-=======
-                (1, 6, 1, 6)),
->>>>>>> adds new extents capability for indexing video frames
             (
                 np.array([
                     [0, 0, 0, 0, 0, 0, 0],
@@ -177,11 +169,7 @@ def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
                     [0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0, 0, 0]]),
                 (5, 5),
-<<<<<<< HEAD
                 ((2, 7, 2, 7), ((0, 0), (0, 0)))),
-=======
-                (2, 7, 2, 7)),
->>>>>>> adds new extents capability for indexing video frames
             (
                 np.array([
                     [1, 1, 0, 0, 0, 0, 0],
@@ -192,11 +180,7 @@ def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
                     [0, 0, 0, 0, 0, 0, 0],
                     [0, 0, 0, 0, 0, 0, 0]]),
                 (5, 5),
-<<<<<<< HEAD
                 ((0, 3, 0, 4), ((2, 0), (1, 0)))),
-=======
-                (-2, 3, -1, 4)),
->>>>>>> adds new extents capability for indexing video frames
             (
                 np.array([
                     [0, 0, 0, 0, 0, 0, 0],
@@ -207,11 +191,7 @@ def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
                     [1, 1, 1, 1, 1, 1, 1],
                     [0, 0, 0, 0, 0, 0, 0]]),
                 (2, 2),
-<<<<<<< HEAD
                 ((3, 5, 3, 5), ((0, 0), (0, 0)))),
-=======
-                (3, 5, 3, 5)),
->>>>>>> adds new extents capability for indexing video frames
             (
                 np.array([
                     [0, 0, 0, 0, 0, 0, 0],

--- a/tests/transforms/test_array_utils.py
+++ b/tests/transforms/test_array_utils.py
@@ -132,3 +132,103 @@ def test_crop_array_raises_error(arr):
 def test_center_pad_2d(arr, shape, value, allow_overflow, expected):
     np.testing.assert_equal(
         expected, au.center_pad_2d(arr, shape, value, allow_overflow))
+
+
+@pytest.mark.parametrize(
+        ("arr", "shape", "expected"),
+        [
+            (
+                np.array([
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 1, 1, 1, 0, 0],
+                    [0, 0, 1, 1, 1, 0, 0],
+                    [0, 0, 1, 1, 1, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0]]),
+                (5, 5),
+                (1, 6, 1, 6)),
+            (
+                np.array([
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 1, 1, 0, 0, 0],
+                    [0, 0, 1, 1, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0]]),
+                (5, 5),
+                (1, 6, 1, 6)),
+            (
+                np.array([
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 1, 1, 0, 0],
+                    [0, 0, 0, 1, 1, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0]]),
+                (5, 5),
+                (2, 7, 2, 7)),
+            (
+                np.array([
+                    [1, 1, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0]]),
+                (5, 5),
+                (-2, 3, -1, 4)),
+            (
+                np.array([
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [1, 1, 1, 1, 1, 1, 1],
+                    [1, 1, 1, 1, 1, 1, 1],
+                    [1, 1, 1, 1, 1, 1, 1],
+                    [1, 1, 1, 1, 1, 1, 1],
+                    [1, 1, 1, 1, 1, 1, 1],
+                    [0, 0, 0, 0, 0, 0, 0]]),
+                (2, 2),
+                (3, 5, 3, 5)),
+            (
+                np.array([
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [1, 1, 1, 1, 1, 1, 1],
+                    [1, 1, 1, 1, 1, 1, 1],
+                    [1, 1, 1, 1, 1, 1, 1],
+                    [1, 1, 1, 1, 1, 1, 1],
+                    [1, 1, 1, 1, 1, 1, 1],
+                    [0, 0, 0, 0, 0, 0, 0]]),
+                (3, 3),
+                (2, 5, 2, 5)),
+            ])
+def test_content_extents(arr, shape, expected):
+    bounds = au.content_extents(arr, shape)
+    assert np.all(bounds == expected)
+
+
+@pytest.mark.parametrize(
+        ("arr", "shape"),
+        [
+            (
+                np.array([
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 1, 1, 1, 0, 0],
+                    [0, 0, 1, 2, 2, 0, 0],
+                    [0, 0, 1, 1, 3, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0]]),
+                (5, 5)),
+            ])
+def test_compare_crop_pad_and_extents(arr, shape):
+    """check that cropping and padding an image
+    is the same as getting the extents and
+    indexing the array (i.e. as would be applied to video frame)
+    """
+    cropped_padded = au.center_pad_2d(au.crop_2d_array(arr), shape)
+    extents = au.content_extents(arr, shape)
+    indexed = arr[extents[0]:extents[1], extents[2]:extents[3]]
+    assert np.all(cropped_padded == indexed)


### PR DESCRIPTION
This PR should merge after #33

NOTE: I don't feel like the code in `rois/array_utils.py` is optimal, and I don't think the test coverage for this new function is complete. But, the basic functionality I want is there, and I want to merge and move on to finishing the pipeline and come back to this when corner cases come up.

Purpose of the function `content_extents`:
* given an ROI object, give back some extents and padding to index and pad a video frame

Example:
![image](https://user-images.githubusercontent.com/32312979/80024472-001abd00-8494-11ea-84a9-e849dc7df50f.png)
from:
```
import segmentation_labeling_app.rois.rois as rois
import segmentation_labeling_app.transforms.array_utils as au
import matplotlib.pyplot as plt
import numpy as np

# get an ROI and its mask
roi = rois.ROI.roi_from_query(1972)
mask = roi.generate_ROI_mask()

# make a moview frame with context around the ROI
x = np.arange(512)
z = np.meshgrid(np.sin(x/4), np.cos(x/4))
frame = np.abs(z[0] + z[1]) * 0.4
frame += roi._sparse_coo.toarray()

# use the new function to extract the part of the movie
# frame based on the ROI
e, pad = au.content_extents(roi._sparse_coo, shape=(128, 128), target_shape=frame.shape)
frame_extract = np.pad(frame[e[0]: e[1], e[2]:e[3]], pad)

f, a = plt.subplots(1, 3, clear=True, num=1)
a[0].imshow(mask)
a[0].set_title('mask')
a[1].imshow(frame)
a[1].set_title('movie frame')
a[2].imshow(frame_extract)
a[2].set_title('extracted region of frame')
```

changing the roi placement:
```
roi = rois.ROI.roi_from_query(1972)
roi._sparse_coo.row -= 60
```
![image](https://user-images.githubusercontent.com/32312979/80024687-4ff98400-8494-11ea-9508-34202908bc2a.png)

and again:
```
roi = rois.ROI.roi_from_query(1972)
roi._sparse_coo.row += 400
roi._sparse_coo.col += 370
```
![image](https://user-images.githubusercontent.com/32312979/80024814-7ae3d800-8494-11ea-9696-9ec32059126f.png)
