### PR TITLE
switches from sqlite to postgres input for uploader

### DIFF
--- a/slapp/rois.py
+++ b/slapp/rois.py
@@ -1,31 +1,11 @@
 from typing import List, Tuple, Union
-import json
-from pathlib import Path
 from scipy.sparse import coo_matrix
 import numpy as np
 import cv2
-import sqlite3
 
 import slapp.utils.query_utils as query_utils
 from slapp.transforms.array_utils import (
         center_pad_2d, crop_2d_array)
-
-
-sql_create_rois_table = """ CREATE TABLE IF NOT EXISTS rois_prelabeling (
-                            id integer PRIMARY KEY,
-                            transform_hash text NOT NULL,
-                            ophys_segmentation_commit_hash text NOT NULL,
-                            creation_date text NOT NULL,
-                            upload_date text,
-                            manifest text NOT NULL,
-                            experiment_id integer NOT NULL,
-                            roi_id integer NOT NULL);"""
-
-sql_insert_roi = """ INSERT INTO rois_prelabeling (transform_hash,
-                     ophys_segmentation_commit_hash,
-                     creation_date, upload_date, manifest, experiment_id,
-                     roi_id)
-                     VALUES (?, ?, ?, ?, ?, ?, ?) """
 
 
 def binary_mask_from_threshold(

--- a/slapp/transfers/upload.py
+++ b/slapp/transfers/upload.py
@@ -6,11 +6,11 @@ import slapp.utils.query_utils as query_utils
 
 
 class UploadSchema(argschema.ArgSchema):
-    sql_filter = argschema.fields.Str(
-        required=False,
-        default="",
-        missing="",
-        description="SQL query filter, starting with 'WHERE'")
+    roi_manifests_ids = argschema.fields.List(
+        argschema.fields.Int,
+        required=True,
+        description=("specifies the values of roi_manifests.ids "
+                     "to include in the upload"))
     s3_bucket_name = argschema.fields.Str(
         required=True,
         description="destination bucket name")
@@ -34,8 +34,9 @@ class LabelDataUploader(argschema.ArgSchemaParser):
         self.timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
 
         # get the specified per-ROI manifests
+        idstr = repr(self.args['roi_manifests_ids'])[1:-1]
         query_string = ("SELECT manifest FROM roi_manifests "
-                        f"{self.args['sql_filter']}")
+                        f"WHERE id in ({idstr})")
         manifests = [r['manifest'] for r in db_conn.query(query_string)]
 
         # upload the per-ROI manifests

--- a/slapp/transfers/utils.py
+++ b/slapp/transfers/utils.py
@@ -36,7 +36,7 @@ def object_exists(bucket, key):
     try:
         client.head_object(Bucket=bucket, Key=key)
         exists = True
-    except ClientError as exc:
+    except ClientError:
         pass
     return exists
 

--- a/tests/transfers/test_transfer_utils.py
+++ b/tests/transfers/test_transfer_utils.py
@@ -119,37 +119,6 @@ def test_upload_manifest_contents(
         assert (s3_manifest[key] == expected[key])
 
 
-def test_get_manifests_from_db(db_file):
-    conn = sqlite3.connect(db_file)
-    test_dict = {
-            "key1": "value1",
-            "key2": "value2",
-            "key3": "value3",
-            "key4": "value4"}
-    tstr = json.dumps(test_dict)
-    for _ in range(4):
-        conn.execute(
-                "INSERT INTO manifest_table (manifest) VALUES ('%s')" % tstr)
-    conn.commit()
-    conn.close()
-
-    results = utils.get_manifests_from_db(db_file, "manifest_table")
-    assert len(results) == 4
-    for r in results:
-        assert set(list(r.keys())) == set(list(test_dict.keys()))
-        for key in test_dict.keys():
-            assert r[key] == test_dict[key]
-
-    results = utils.get_manifests_from_db(
-            db_file, "manifest_table", "WHERE rowid=2")
-
-    assert len(results) == 1
-    for r in results:
-        assert set(list(r.keys())) == set(list(test_dict.keys()))
-        for key in test_dict.keys():
-            assert r[key] == test_dict[key]
-
-
 def test_manifest_file_from_jsons(list_of_dicts, tmpdir_factory):
     fn = tmpdir_factory.mktemp("manifest_file").join("manifest.jsonl")
     utils.manifest_file_from_jsons(str(fn), list_of_dicts)

--- a/tests/transfers/test_upload.py
+++ b/tests/transfers/test_upload.py
@@ -7,7 +7,7 @@ import slapp.transfers.upload as up
 
 
 @pytest.fixture
-def mock_db_conn_fixture(request, tmpdir_factory):
+def mock_db_conn_fixture(tmpdir_factory):
     tdir = tmpdir_factory.mktemp("contents")
     keys = [
             'source-ref', 'roi-mask-source-ref', 'video-source-ref',

--- a/tests/transfers/test_upload.py
+++ b/tests/transfers/test_upload.py
@@ -43,7 +43,7 @@ def bucket():
 def test_LabelDataUploader(mock_db_conn_fixture, bucket, timestamp):
     args = {
             's3_bucket_name': bucket,
-            'sql_filter': "",
+            'roi_manifests_ids': [0],
             'timestamp': timestamp,
             'prefix': 'abc/def',
             }


### PR DESCRIPTION
General comments welcome. Of particular interest:
- [x] calling method, i.e. `sql_filter` is pretty wide open. (changed to `--roi_manifests_ids` arg)
- [x] @njmei Check out my tests mocking the dbconnection. Let me know if you see improvement areas. (see comments)

This command:
```
python -m slapp.transfers.upload \
    --roi_manifests_ids 1 2 3 \
    --s3_bucket_name danielk-ophys-dev \
    --prefix pr_demo
```
created objects in an S3 bucket:
![image](https://user-images.githubusercontent.com/32312979/80541166-89803280-895f-11ea-913f-cfd0bcc4f56f.png)

and the contents of that `manifest.jsonl` are:
```
{"experiment-id": 840460366, "roi-id": 1575056, "source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/outline_1575056.png", "roi-mask-source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/mask_1575056.png", "video-source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/video_1575056.mp4", "max-source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/max_1575056.png", "avg-source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/avg_1575056.png", "trace-source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/trace_1575056.json"}
{"experiment-id": 840460366, "roi-id": 1575085, "source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/outline_1575085.png", "roi-mask-source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/mask_1575085.png", "video-source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/video_1575085.mp4", "max-source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/max_1575085.png", "avg-source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/avg_1575085.png", "trace-source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/trace_1575085.json"}
{"experiment-id": 840460366, "roi-id": 1575113, "source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/outline_1575113.png", "roi-mask-source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/mask_1575113.png", "video-source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/video_1575113.mp4", "max-source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/max_1575113.png", "avg-source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/avg_1575113.png", "trace-source-ref": "s3://danielk-ophys-dev/pr_demo/20200428144657/trace_1575113.json"}
```