### PR TITLE
allow None for prefix

### DIFF
--- a/slapp/transfers/upload.py
+++ b/slapp/transfers/upload.py
@@ -16,8 +16,8 @@ class UploadSchema(argschema.ArgSchema):
         description="destination bucket name")
     prefix = argschema.fields.Str(
         required=False,
-        default="",
-        missing="",
+        default=None,
+        allow_none=True,
         description="key prefix for manifest and contents")
     timestamp = argschema.fields.Bool(
         required=False,
@@ -42,7 +42,10 @@ class LabelDataUploader(argschema.ArgSchemaParser):
         # upload the per-ROI manifests
         prefix = self.args['prefix']
         if self.args['timestamp']:
-            prefix += '/' + self.timestamp
+            if prefix is None:
+                prefix = self.timestamp
+            else:
+                prefix += '/' + self.timestamp
         s3_manifests = []
         for manifest in manifests:
             s3_manifests.append(

--- a/slapp/transfers/upload.py
+++ b/slapp/transfers/upload.py
@@ -9,6 +9,7 @@ class UploadSchema(argschema.ArgSchema):
     roi_manifests_ids = argschema.fields.List(
         argschema.fields.Int,
         required=True,
+        cli_as_single_argument=True,
         description=("specifies the values of roi_manifests.ids "
                      "to include in the upload"))
     s3_bucket_name = argschema.fields.Str(


### PR DESCRIPTION
prefix was `""` by default. This was resulting in S3 URIs like:
`<bucket-name>//<timestamp>/<key>` 
changed prefix default to None, which, when left there creates S3 URIs like:
`<bucket name>/<timestamp>/<key>`