### PR TITLE
Feature/upload tweaks

### DIFF
--- a/slapp/transfers/upload.py
+++ b/slapp/transfers/upload.py
@@ -38,7 +38,8 @@ class LabelDataUploader(argschema.ArgSchemaParser):
 
         # get the specified per-ROI manifests
         nrequested = len(self.args['roi_manifests_ids'])
-        self.logger.info(f"Requesting {nrequested} roi manifests from postgres")
+        self.logger.info(
+                f"Requesting {nrequested} roi manifests from postgres")
 
         idstr = repr(self.args['roi_manifests_ids'])[1:-1]
         query_string = ("SELECT id, manifest FROM roi_manifests "
@@ -49,7 +50,7 @@ class LabelDataUploader(argschema.ArgSchemaParser):
         if nman != nrequested:
             manifest_ids = [r['id'] for r in results]
             missing_ids = \
-                    set(self.args['roi_manifests_ids']) - set(manifest_ids)
+                set(self.args['roi_manifests_ids']) - set(manifest_ids)
             self.logger.warning(
                     f"Requested {nrequested}, received {nman}. "
                     f"Missing ids: {missing_ids}")

--- a/slapp/transfers/upload.py
+++ b/slapp/transfers/upload.py
@@ -16,8 +16,8 @@ class UploadSchema(argschema.ArgSchema):
         description="destination bucket name")
     prefix = argschema.fields.Str(
         required=False,
-        default="",
-        missing="",
+        default=None,
+        allow_none=True,
         description="key prefix for manifest and contents")
     timestamp = argschema.fields.Bool(
         required=False,
@@ -42,7 +42,10 @@ class LabelDataUploader(argschema.ArgSchemaParser):
         # upload the per-ROI manifests
         prefix = self.args['prefix']
         if self.args['timestamp']:
-            prefix += '/' + self.timestamp
+            if prefix is None:
+                prefix = self.timestamp
+            else:
+                prefix += '/' + self.timestamp
         s3_manifests = []
         for manifest in manifests:
             s3_manifests.append(

--- a/slapp/transfers/upload.py
+++ b/slapp/transfers/upload.py
@@ -9,6 +9,7 @@ class UploadSchema(argschema.ArgSchema):
     roi_manifests_ids = argschema.fields.List(
         argschema.fields.Int,
         required=True,
+        cli_as_single_argument=True,
         description=("specifies the values of roi_manifests.ids "
                      "to include in the upload"))
     s3_bucket_name = argschema.fields.Str(


### PR DESCRIPTION
3 minor changes:
* removes an extra `/` in the s3 URIs when no prefix is provided: `<bucket>//<timestamp>/<key>` -> `<bucket>/<timestamp>/<key>`
* sets an argschema arg for list input to get rid of annoying future warning.
* adds logging info output so user knows something is happening.

Sample output:
```
$ python -m slapp.transfers.upload --input_json input2.json 
INFO:LabelDataUploader:Requesting 11 roi manifests from postgres
WARNING:LabelDataUploader:Requested 11, received 10. Missing ids: {999999}
INFO:LabelDataUploader:bucket destination is s3://dev.slapp.alleninstitute.org/20200429074103
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
INFO:LabelDataUploader:uploaded source data for 10 / 10 ROIs
INFO:LabelDataUploader:uploaded s3://dev.slapp.alleninstitute.org/20200429074103/manifest.jsonl

```