### PR TITLE
deployment tweaks

### DIFF
--- a/slapp/transfers/upload.py
+++ b/slapp/transfers/upload.py
@@ -80,10 +80,13 @@ class LabelDataUploader(argschema.ArgSchemaParser):
         # upload the manifest
         tfile = tempfile.NamedTemporaryFile()
         utils.manifest_file_from_jsons(tfile.name, s3_manifests)
+        # NOTE: the docs for SageMaker GroundTruth specify a JSON Lines format
+        # but, throws an error with the .jsonl extension
+        # setting here to .json extension to resolve the error.
         s3_manifest = utils.upload_file(
                 tfile.name,
                 self.args['s3_bucket_name'],
-                key=prefix + "/manifest.jsonl")
+                key=prefix + "/manifest.json")
         self.logger.info(f"uploaded {s3_manifest}")
         tfile.close()
 

--- a/slapp/transforms/array_utils.py
+++ b/slapp/transforms/array_utils.py
@@ -247,3 +247,31 @@ def downsample_array(
         array_out[i] = sampler(array, bin_indices)
 
     return array_out
+
+
+def normalize_array(
+        array: np.ndarray, lower_cutoff: float,
+        upper_cutoff: float) -> np.ndarray:
+    """Normalize an array into uint8 with cutoff values
+
+    Parameters
+    ----------
+    array: numpy.ndarray (float)
+        array to be normalized
+    lower_cutoff: float
+        threshold, below which will be = 0
+    upper_cutoff: float
+        threshold, abovewhich will be = 255
+
+    Returns
+    -------
+    normalized: numpy.ndarray (uint8)
+        normalized array
+
+    """
+    normalized = np.copy(array)
+    normalized[array < lower_cutoff] = lower_cutoff
+    normalized[array > upper_cutoff] = upper_cutoff
+    normalized -= lower_cutoff
+    normalized = np.uint8(normalized * 255 / (upper_cutoff - lower_cutoff))
+    return normalized

--- a/slapp/transforms/transform_pipeline.py
+++ b/slapp/transforms/transform_pipeline.py
@@ -76,6 +76,10 @@ class TransformPipelineSchema(argschema.ArgSchema):
         default=0.999,
         description=("upper quantile threshold for avg projection "
                      "histogram adjustment"))
+    mp4_bitrate = argschema.fields.Str(
+        required=False,
+        default="192k",
+        description="passed as bitrate to imageio-ffmpeg.write_frames()")
 
     @mm.pre_load
     def set_segmentation_run_id(self, data, **kwargs):
@@ -178,7 +182,9 @@ class TransformPipeline(argschema.ArgSchemaParser):
             sub_video = np.pad(
                     downsampled_video[:, inds[0]:inds[1], inds[2]:inds[3]],
                     ((0, 0), *pads))
-            transform_to_mp4(sub_video, str(sub_video_path), playback_fps)
+            transform_to_mp4(
+                    sub_video, str(sub_video_path),
+                    playback_fps, self.args['mp4_bitrate'])
 
             # sub-projections
             sub_max = np.pad(

--- a/slapp/transforms/transform_pipeline.py
+++ b/slapp/transforms/transform_pipeline.py
@@ -115,9 +115,10 @@ class TransformPipeline(argschema.ArgSchemaParser):
     default_schema = TransformPipelineSchema
 
     def run(self, db_conn: query_utils.DbConnection):
+        self.timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
         output_dir = Path(self.args['artifact_basedir']) / \
-                     f"seg_run_id_{self.args['segmentation_run_id']}" / \
-                     datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+            f"seg_run_id_{self.args['segmentation_run_id']}" / \
+            self.timestamp
         os.makedirs(output_dir, exist_ok=True)
 
         # get all ROI ids from this segmentation run

--- a/slapp/transforms/transform_pipeline.py
+++ b/slapp/transforms/transform_pipeline.py
@@ -5,6 +5,7 @@ import os
 import json
 import imageio
 import numpy as np
+import datetime
 import slapp.utils.query_utils as query_utils
 from slapp.rois import ROI
 from slapp.transforms.video_utils import (
@@ -115,7 +116,8 @@ class TransformPipeline(argschema.ArgSchemaParser):
 
     def run(self, db_conn: query_utils.DbConnection):
         output_dir = Path(self.args['artifact_basedir']) / \
-                     f"segmentation_run_id_{self.args['segmentation_run_id']}"
+                     f"seg_run_id_{self.args['segmentation_run_id']}" / \
+                     datetime.datetime.now().strftime('%Y%m%d%H%M%S')
         os.makedirs(output_dir, exist_ok=True)
 
         # get all ROI ids from this segmentation run

--- a/slapp/transforms/transform_pipeline.py
+++ b/slapp/transforms/transform_pipeline.py
@@ -14,6 +14,12 @@ from slapp.transforms.array_utils import (
         content_extents, downsample_array, normalize_array)
 
 
+insert_str_template = (
+        "INSERT INTO roi_manifests "
+        "(manifest, transform_hash, roi_id) "
+        "VALUES ('{}', '{}', {})")
+
+
 class TransformPipelineException(Exception):
     pass
 
@@ -228,11 +234,10 @@ class TransformPipeline(argschema.ArgSchemaParser):
             manifest['avg-source-ref'] = str(avg_proj_path)
             manifest['trace-source-ref'] = str(trace_path)
 
-            insert_str = (
-                    "INSERT INTO roi_manifests "
-                    "(manifest, transform_hash, roi_id) "
-                    f"VALUES ('{json.dumps(manifest)}', "
-                    f"'{os.environ['TRANSFORM_HASH']}', {roi.roi_id})")
+            insert_str = insert_str_template.format(
+                    json.dumps(manifest),
+                    os.environ['TRANSFORM_HASH'],
+                    roi.roi_id)
 
             insert_statements.append(insert_str)
 

--- a/slapp/transforms/transform_pipeline.py
+++ b/slapp/transforms/transform_pipeline.py
@@ -141,16 +141,21 @@ class TransformPipeline(argschema.ArgSchemaParser):
         # strategy for normalization: normalize entire video and projections
         # on quantiles of average projection before per-ROI processing
         avg_projection = np.mean(downsampled_video, axis=0)
+        max_projection = np.max(downsampled_video, axis=0)
+        quantiles = [self.args['image_lower_quantile'],
+                     self.args['image_upper_quantile']]
+        # normalize movie and avg according to avg quantiles
         lower_cutoff, upper_cutoff = np.quantile(
-                avg_projection.flatten(),
-                [
-                    self.args['image_lower_quantile'],
-                    self.args['image_upper_quantile']])
+                avg_projection.flatten(), quantiles)
         avg_projection = normalize_array(
                 avg_projection, lower_cutoff, upper_cutoff)
         downsampled_video = normalize_array(
                 downsampled_video, lower_cutoff, upper_cutoff)
-        max_projection = np.max(downsampled_video, axis=0)
+        # normalize max on its own quantiles, to avoid saturation
+        lower_cutoff, upper_cutoff = np.quantile(
+                max_projection.flatten(), quantiles)
+        max_projection = normalize_array(
+                max_projection, lower_cutoff, upper_cutoff)
 
         playback_fps = self.args['output_fps'] * self.args['playback_factor']
 

--- a/slapp/transforms/transform_pipeline.py
+++ b/slapp/transforms/transform_pipeline.py
@@ -44,13 +44,13 @@ class TransformPipelineSchema(argschema.ArgSchema):
         required=True,
         default=0.1,
         description=("quantile threshold for outlining an ROI. "))
-    input_fps = argschema.fields.Int(
+    input_fps = argschema.fields.Float(
         required=False,
-        default=31,
+        default=31.0,
         description="frames per second of input movie")
-    output_fps = argschema.fields.Int(
+    output_fps = argschema.fields.Float(
         required=False,
-        default=4,
+        default=4.0,
         description="frames per second of downsampled movie")
     playback_factor = argschema.fields.Float(
         required=False,

--- a/slapp/transforms/video_utils.py
+++ b/slapp/transforms/video_utils.py
@@ -47,7 +47,7 @@ def downsample_h5_video(
 
 
 def transform_to_mp4(video: np.ndarray, output_path: str,
-                     fps: float):
+                     fps: float, bitrate: str = "192k"):
     """
     Function to transform 2p gray scale video into a mp4
     video using imageio_ffmpeg.
@@ -63,7 +63,8 @@ def transform_to_mp4(video: np.ndarray, output_path: str,
                               video[0].shape,
                               pix_fmt_in="gray",
                               pix_fmt_out="gray",
-                              fps=fps)
+                              fps=fps,
+                              bitrate=bitrate)
     writer.send(None)
     for frame in video:
         writer.send(frame)

--- a/slapp/transforms/video_utils.py
+++ b/slapp/transforms/video_utils.py
@@ -46,17 +46,6 @@ def downsample_h5_video(
     return video_out
 
 
-def normalize_video(video: np.ndarray):
-    """
-    Function to normalize video by its global max and maximum 8 bit value
-    Args:
-        video: Video to be normalized with shape (time, row, col)
-    Returns:
-        norm_frames: normalized video (time, row, col)
-    """
-    return np.uint8(video / video.max() * 255)
-
-
 def transform_to_mp4(video: np.ndarray, output_path: str,
                      fps: float):
     """
@@ -70,13 +59,12 @@ def transform_to_mp4(video: np.ndarray, output_path: str,
     Returns:
 
     """
-    norm_video = normalize_video(video)
     writer = mpg.write_frames(output_path,
                               video[0].shape,
                               pix_fmt_in="gray",
                               pix_fmt_out="gray",
                               fps=fps)
     writer.send(None)
-    for frame in norm_video:
+    for frame in video:
         writer.send(frame)
     writer.close()

--- a/slapp/transforms/video_utils.py
+++ b/slapp/transforms/video_utils.py
@@ -58,7 +58,7 @@ def normalize_video(video: np.ndarray):
 
 
 def transform_to_mp4(video: np.ndarray, output_path: str,
-                     fps: int):
+                     fps: float):
     """
     Function to transform 2p gray scale video into a mp4
     video using imageio_ffmpeg.

--- a/tests/transforms/test_array_utils.py
+++ b/tests/transforms/test_array_utils.py
@@ -330,3 +330,23 @@ def test_downsample_exceptions(array, input_fps, output_fps, random_seed,
                 output_fps=output_fps,
                 strategy=strategy,
                 random_seed=random_seed)
+
+
+@pytest.mark.parametrize(
+        "array, lower_cutoff, upper_cutoff, expected",
+        [
+            (
+                np.array([
+                    [0.0, 100.0, 200.0],
+                    [300.0, 400.0, 500.0],
+                    [600.0, 700.0, 800.0]]),
+                250, 650,
+                np.uint8([
+                    [0, 0, 0],
+                    [31, 95, 159],
+                    [223, 255, 255]]))
+                ]
+        )
+def test_normalize_array(array, lower_cutoff, upper_cutoff, expected):
+    normalized = au.normalize_array(array, lower_cutoff, upper_cutoff)
+    np.testing.assert_array_equal(normalized, expected)

--- a/tests/transforms/test_transform_pipeline.py
+++ b/tests/transforms/test_transform_pipeline.py
@@ -137,6 +137,12 @@ def test_transform_pipeline(tmp_path, monkeypatch, mock_db_conn_fixture,
         mock_imageio.imsave.assert_has_calls(calls, any_order=False)
 
     # Assert that created manifests are correct
-    outdir_name = f"seg_run_id_{input_data['segmentation_run_id']}"
-    expected_outdir = Path(input_data["artifact_basedir"]) / outdir_name
-    [call(m, expected_outdir) for m in expected_manifests]
+    expected_insert_statements = [
+            transform_pipeline.insert_str_template.format(
+                manifest,
+                os.environ['TRANSFORM_HASH'],
+                manifest['roi-id'])
+            for manifest in expected_manifests]
+
+    mock_db_conn_fixture.bulk_insert.assert_has_calls(
+            [call(expected_insert_statements)])

--- a/tests/transforms/test_transform_pipeline.py
+++ b/tests/transforms/test_transform_pipeline.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from functools import partial
 import os
 import numpy as np
+import json
 
 from slapp.transforms import transform_pipeline
 
@@ -139,7 +140,7 @@ def test_transform_pipeline(tmp_path, monkeypatch, mock_db_conn_fixture,
     # Assert that created manifests are correct
     expected_insert_statements = [
             transform_pipeline.insert_str_template.format(
-                manifest,
+                json.dumps(manifest),
                 os.environ['TRANSFORM_HASH'],
                 manifest['roi-id'])
             for manifest in expected_manifests]

--- a/tests/transforms/test_transform_pipeline.py
+++ b/tests/transforms/test_transform_pipeline.py
@@ -90,17 +90,23 @@ def test_transform_pipeline(tmp_path, monkeypatch, mock_db_conn_fixture,
         manifest = create_expected_manifest(**meta, save_path=str(tmp_path))
         expected_manifests.append(manifest)
 
+    def normalize_side_effect(value, dummya, dummyb):
+        return value
+
     mock_downsample_h5_video = MagicMock(return_value=np.zeros((3, 5, 5)))
+    mock_normalize = MagicMock(side_effect=normalize_side_effect)
     mock_imageio = MagicMock()
     mock_content_extents = MagicMock(return_value=([0, 0, 2, 2], [1, 1, 1, 1]))
     mock_transform_to_mp4 = MagicMock()
     mock_np = MagicMock()
+    mock_np.quantile = MagicMock(return_value=(0, 1))
 
     mpatcher = partial(monkeypatch.setattr, target=transform_pipeline)
     mpatcher(name="ROI", value=mock_roi)
     mpatcher(name="downsample_h5_video", value=mock_downsample_h5_video)
     mpatcher(name="imageio", value=mock_imageio)
     mpatcher(name="content_extents", value=mock_content_extents)
+    mpatcher(name="normalize_array", value=mock_normalize)
     mpatcher(name="transform_to_mp4", value=mock_transform_to_mp4)
     mpatcher(name="np", value=mock_np)
 

--- a/tests/transforms/test_transform_pipeline.py
+++ b/tests/transforms/test_transform_pipeline.py
@@ -138,4 +138,4 @@ def test_transform_pipeline(tmp_path, monkeypatch, mock_db_conn_fixture,
     # Assert that created manifests are correct
     outdir_name = f"segmentation_run_id_{input_data['segmentation_run_id']}"
     expected_outdir = Path(input_data["artifact_basedir"]) / outdir_name
-    expected_calls = [call(m, expected_outdir) for m in expected_manifests]
+    [call(m, expected_outdir) for m in expected_manifests]

--- a/tests/transforms/test_video_utils.py
+++ b/tests/transforms/test_video_utils.py
@@ -67,5 +67,6 @@ def test_mp4_conversion(tmp_path):
     reader.close()
 
     assert read_video.shape == video.shape
-    # mp4 is not lossless compression, so can't test for exact match
+    # the default settings for imageio-ffmpeg are not lossless
+    # so can't test for exact match
     np.testing.assert_allclose(read_video, video, atol=25)

--- a/tests/transforms/test_video_utils.py
+++ b/tests/transforms/test_video_utils.py
@@ -4,6 +4,7 @@ import cv2
 import imageio
 import h5py
 import slapp.transforms.video_utils as transformations
+from slapp.transforms.array_utils import normalize_array
 
 test_frame = np.arange(25).reshape(5, 5)
 test_video = np.stack([test_frame]*2, axis=0)
@@ -60,7 +61,10 @@ def test_mp4_conversion(video_fixture, tmp_path):
 
     fps = 30
 
-    transformations.transform_to_mp4(video=video_fixture,
+    normalized_video = normalize_array(
+            video_fixture, 0, video_fixture.max())
+
+    transformations.transform_to_mp4(video=normalized_video,
                                      output_path=output_path.as_posix(),
                                      fps=fps),
 


### PR DESCRIPTION
## These are deployment tweaks required and requested during Pika's dev testing of the app.
### 1. changing manifest extension from `.jsonl` to `.json`
### 2. linking movie frame rate and trace time axis
webapp movie playback defined by `fps` passed to imageio_ffmpeg and trace playback defined by `pointInterval`. These were not connected. Added a `playback_factor` arg default to 1.0 (real time) that connected these 2 data sources. Demo:
```
import json                                                               
tpath = "/allen/aibs/informatics/labeling_artifacts/segmentation_run_id_954/trace_1575130.json"                                                     
with open(tpath, "r") as f: 
    print(json.load(f)['pointInterval'])                                                                            
0.25
```
and
```
$ ffmpeg -i /allen/aibs/informatics/labeling_artifacts/segmentation_run_id_954/video_1575130.mp4
...
    Stream #0:0(und): Video: h264 (High) ... 4 fps, 4 tbr, 16384 tbn, 8 tbc (default)
...
```
note that in python:
```
import imageio_ffmpeg as mpg                                              
vpath = "/allen/aibs/informatics/labeling_artifacts/segmentation_run_id_954/video_1575130.mp4"                                                    
frames, seconds = mpg.count_frames_and_secs(vpath) 
print(frames / seconds)                                                  
4.047058823529412
```
`imageio-ffmpeg` has some [known issue](https://github.com/imageio/imageio-ffmpeg/blob/58524a3ac54352f945d2d62ecd938f3a2c1ac8a8/imageio_ffmpeg/_io.py#L23-L31).

### 3. Added a video/image normalization strategy.
Thus far the strategy is:
* downsample the video and take average and max projections.
* normalize video and average projection based on quantiles of average projection.
* normalize max projection based on quantiles of max projection. (saturates when treated like video and avg)
* normalization completely at experiment level.
* no per-ROI normalization (in this iteration.)

### 4. exposing [bitrate parameter](https://github.com/imageio/imageio-ffmpeg/blob/80e37882d057f42dd24043edd2e49cd364683f16/imageio_ffmpeg/_io.py#L304) for potentially helping to control movie sizes.

### 5. Added timestamp to local transform results folder.
To avoid re-writing some manifest contents. Could get confusing.