### PR TITLE
Fix post-annotation lambda to properly return data

### DIFF
--- a/slapp/lambdas/post_annotation.py
+++ b/slapp/lambdas/post_annotation.py
@@ -1,6 +1,12 @@
 import json
 import boto3
 from urllib.parse import urlparse
+import math
+import logging
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
 
 def lambda_handler(event, context) -> dict:
@@ -8,35 +14,98 @@ def lambda_handler(event, context) -> dict:
     The lambda function to be run upon the completion of a labeling task
     by a user. Transports the data to an s3 bucket for later use or movement to
     the allen server.
-    Args:
-        event: dict structure containing input data passed from label task to
-        lambda function
-        context: context of the event
-    Returns: bool status of uploading to bucket
-    """
-    consolidated_labels = []
+    Parameters
+    ----------
+        event: dict
+            Json-formatted event from Sagemaker Ground Truth
+            Event doc: https://docs.aws.amazon.com/sagemaker/latest/dg/sms-custom-templates-step3.html    # noqa
+        context: object
+            Lambda Context runtime methods and attributes
+            Context doc: https://docs.aws.amazon.com/lambda/latest/dg/python-context-object.html    #noqa
 
+    Returns
+    -------
+        Json-formatted list of consolidated labels, with majority
+        label calculated if it exists.
+        [
+            {
+                "datasetObjectId": <id>,
+                "consolidatedAnnotation": {
+                    "content" : {
+                        <labelAttributeName> : {
+                            "sourceData": <source>,
+                            "majorityLabel": <majority label>,
+                            "workerAnnotations": [
+                                {"workerId": <worker_id>, "roiLabel": <label>},
+                                ...
+                            ]
+                        }
+                    }
+                }
+            },
+            ...
+        ]
+        Return doc: https://docs.aws.amazon.com/sagemaker/latest/dg/sms-custom-templates-step3.html    # noqa
+    """
+    # For CloudWatch Logs
+    logger.info("#### EVENT ####")
+    logger.info(json.dumps(event))
+    consolidated_labels = []
+    label_attribute_name = event["labelAttributeName"]
     parsed_url = urlparse(event['payload']['s3Uri'])
     s3 = boto3.client('s3')
     textFile = s3.get_object(Bucket=parsed_url.netloc, Key=parsed_url.path[1:])
     filecont = textFile['Body'].read()
     annotations = json.loads(filecont)
-
     for dataset in annotations:
-        for annotation in dataset['annotations']:
-            new_annotation = json.loads(
-                annotation['annotationData']['content'])
-            label = {
-                'datasetObjectId': dataset['datasetObjectId'],
-                'consolidatedAnnotation': {
-                    'content': {
-                        event['labelAttributeName']: {
-                            'workerId': annotation['workerId'],
-                            'result': new_annotation,
-                            'labeledContent': dataset['dataObject']
-                        }
+        consolidated_dataset = {
+            "datasetObjectId": dataset["datasetObjectId"]
+        }
+        worker_annotations = []
+        worker_labels = []
+        # Consolidate list of annotations
+        for labels in dataset["annotations"]:
+            label_dict = json.loads(
+                labels.get("annotationData").get("content")).get("roiLabel")
+            if label_dict is not None:
+                label = label_dict["label"]
+            else:
+                label = None
+            worker_annotations.append(
+                {"workerId": labels["workerId"], "roiLabel": label})
+            if label == "cell":
+                worker_labels.append(1)
+            elif label == "not cell":
+                worker_labels.append(0)
+            else:    # possible None if timeout
+                pass
+        majority = compute_majority(worker_labels)
+        consolidated_dataset.update({
+            "consolidatedAnnotation": {
+                "content": {
+                    label_attribute_name: {
+                        "sourceData": dataset["dataObject"]["s3Uri"],
+                        "majorityLabel": majority,
+                        "workerAnnotations": worker_annotations
                     }
                 }
             }
-            consolidated_labels.append(label)
+        })
+        consolidated_labels.append(consolidated_dataset)
+    logger.info("### CONSOLIDATED LABELS ###")
+    logger.info(json.dumps(consolidated_labels))
     return consolidated_labels
+
+
+def compute_majority(labels):
+    label_count = len(labels)
+    threshold = math.ceil(label_count/2)
+    yeas = sum(labels)
+    nays = len(labels) - sum(labels)
+    if yeas >= threshold:
+        majority = "cell"
+    elif nays >= threshold:
+        majority = "not cell"
+    else:
+        majority = None
+    return majority

--- a/template.yml
+++ b/template.yml
@@ -41,6 +41,8 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/CloudWatchEventsFullAccess'
+        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+        - 'arn:aws:iam::aws:policy/AmazonS3FullAccess'
       Policies:
         - PolicyDocument:
             Statement:

--- a/tests/lambdas/resources/consolidation_payload.json
+++ b/tests/lambdas/resources/consolidation_payload.json
@@ -1,0 +1,54 @@
+[
+    {
+      "datasetObjectId": "1",
+      "dataObject": {
+        "s3Uri": "s3://test-bucket/test-img.png"
+      },
+      "annotations": [
+        {
+          "workerId": "private.us-west-2.11111",
+          "annotationData": {
+            "content": "{\"brightness\":\"100\",\"contrast\":\"100\",\"roiLabel\":{\"label\":\"not cell\"}}"
+          }
+        },
+        {
+          "workerId": "private.us-west-2.22222",
+          "annotationData": {
+            "content": "{\"brightness\":\"100\",\"contrast\":\"100\",\"roiLabel\":{\"label\":\"cell\"}}"
+          }
+        },
+        {
+          "workerId": "private.us-west-2.33333",
+          "annotationData": {
+            "content": "{\"brightness\":\"100\",\"contrast\":\"100\",\"roiLabel\":{\"label\":\"cell\"}}"
+          }
+        }
+      ]
+    },
+    {
+      "datasetObjectId": "3",
+      "dataObject": {
+        "s3Uri": "s3://test-bucket/test-img-2.png"
+      },
+      "annotations": [
+        {
+          "workerId": "private.us-west-2.11111",
+          "annotationData": {
+            "content": "{\"brightness\":\"100\",\"contrast\":\"100\",\"roiLabel\":{\"label\":\"not cell\"}}"
+          }
+        },
+        {
+          "workerId": "private.us-west-2.22222",
+          "annotationData": {
+            "content": "{\"brightness\":\"100\",\"contrast\":\"100\",\"roiLabel\":{\"label\":\"not cell\"}}"
+          }
+        },
+        {
+          "workerId": "private.us-west-2.33333",
+          "annotationData": {
+            "content": "{\"brightness\":\"100\",\"contrast\":\"100\",\"roiLabel\":{\"label\":\"not cell\"}}"
+          }
+        }
+      ]
+    }
+  ]

--- a/tests/lambdas/resources/consolidation_request.json
+++ b/tests/lambdas/resources/consolidation_request.json
@@ -1,0 +1,10 @@
+{
+    "version":"2018-10-06",
+    "labelingJobArn":"arn:aws:sagemaker:us-east-1:111111111111:labeling-job/test-labeling-job",
+    "payload":{
+       "s3Uri":"s3://dev.slapp.alleninstitute.org/test_lambda/test_consolidation_payload.json"
+    },
+    "labelAttributeName":"test-label-job",
+    "roleArn":"arn:aws:iam::606907419058:role/gt-lambdas-LambdaExecutionRole-1BADDIO7S6NMP",
+    "outputConfig": "s3://dev.slapp.alleninstitute.org/test_lambda/outputs"
+ }


### PR DESCRIPTION
Compute the majority label (if it exists) when consolidating
annotations.

Add CloudWatch to permissions so Lambda can write logs.

Give full s3 access since we aren't using SageMaker prefix
in our bucket names.

Update tests with real sample payload and events from Sagemaker.

-------

Two ways of testing the lambda:

`sam local invoke PostAnnotationLabelingFunction --event tests/lambdas/resources/consolidation_request.json` => Gets real data stored in s3 and processes it
Also have coverage with s3 service mocked out using pytest.

Validation: Made a test job to do the full integration
![Screen Shot 2020-05-06 at 4 28 45 PM](https://user-images.githubusercontent.com/34227334/81238615-5b31d100-8fb7-11ea-9e0c-7cfd2225fa68.png)
Object Summary:
https://us-west-2.console.aws.amazon.com/sagemaker/groundtruth?region=us-west-2#/details-object/lambda-test-4
