### PR TITLE
Click to expand images rather than hover

### DIFF
--- a/slapp/app/example_ui.html
+++ b/slapp/app/example_ui.html
@@ -43,6 +43,14 @@
     position: relative;
     margin-bottom: 30;
   }
+  .enlarged {
+    position: relative;
+    transform: scale(2);
+    transition: transform 0.35s ease-in-out;
+    z-index: 100;
+    border: 5px solid rgba(235, 235, 235, 1.0);
+    border-radius: 5px;
+  }
   .image-label{
     width: 128;
     margin-bottom:10;
@@ -68,14 +76,6 @@
     background: #d3d3d3;
     flex:10;
     flex-basis:0%;
-  }
-  .image-container:hover * {
-    transform: scale(2);
-    transition: transform 0.35s ease-in-out;
-    position: relative;
-    z-index: 100;
-    border: 10px solid rgba(235, 235, 235, 1.0) !important;
-    border-radius: 10px;
   }
   #roi-mask-thumb {
     background-color: white;
@@ -639,4 +639,9 @@
   
   video.addEventListener("timeupdate", moveTraceLine);
 
+  document.querySelectorAll(".image-container canvas").forEach(function(elem) {
+    elem.addEventListener("click", function () {
+      elem.classList.toggle("enlarged");
+    });
+  });
   </script>

--- a/slapp/app/index.liquid.html
+++ b/slapp/app/index.liquid.html
@@ -72,13 +72,13 @@
     flex:10;
     flex-basis:0%;
   }
-  .image-container:hover * {
+  .enlarged {
+    position: relative;
     transform: scale(2);
     transition: transform 0.35s ease-in-out;
-    position: relative;
     z-index: 100;
-    border: 10px solid rgba(235, 235, 235, 1.0) !important;
-    border-radius: 10px;
+    border: 5px solid rgba(235, 235, 235, 1.0);
+    border-radius: 5px;
   }
   .speed {
     font-size: x-small;
@@ -613,5 +613,12 @@
   }
   
   video.addEventListener("timeupdate", moveTraceLine);
+
+  document.querySelectorAll(".image-container canvas").forEach(function(elem) {
+    elem.addEventListener("click", function () {
+      elem.classList.toggle("enlarged");
+    });
+  });
+      
 
   </script>


### PR DESCRIPTION
Click to expand images rather than hovering.
(FYI the example page hasn't been updated with some of the latest changes, which is why there's still a white background on the ROI stamp)

![click_expand](https://user-images.githubusercontent.com/34227334/81428177-c3e09100-9110-11ea-9f4b-727976708838.gif)
