### PR TITLE
Change produced videos to Webm container and VP9 codec to eliminate green video problems.

### DIFF
--- a/slapp/transforms/transform_pipeline.py
+++ b/slapp/transforms/transform_pipeline.py
@@ -9,7 +9,7 @@ import datetime
 import slapp.utils.query_utils as query_utils
 from slapp.rois import ROI
 from slapp.transforms.video_utils import (
-    downsample_h5_video, transform_to_mp4)
+    downsample_h5_video, transform_to_webm)
 from slapp.transforms.array_utils import (
         content_extents, downsample_array, normalize_array)
 
@@ -62,7 +62,7 @@ class TransformPipelineSchema(argschema.ArgSchema):
     playback_factor = argschema.fields.Float(
         required=False,
         default=1.0,
-        description=("mp4 FPS and trace pointInterval will adjust by this "
+        description=("webm FPS and trace pointInterval will adjust by this "
                      "factor relative to real time."))
     downsampling_strategy = argschema.fields.Str(
         required=False,
@@ -83,7 +83,7 @@ class TransformPipelineSchema(argschema.ArgSchema):
         default=0.999,
         description=("upper quantile threshold for avg projection "
                      "histogram adjustment"))
-    mp4_bitrate = argschema.fields.Str(
+    webm_bitrate = argschema.fields.Str(
         required=False,
         default="192k",
         description="passed as bitrate to imageio-ffmpeg.write_frames()")
@@ -176,7 +176,7 @@ class TransformPipeline(argschema.ArgSchemaParser):
             # mask and outline from ROI class
             mask_path = output_dir / f"mask_{roi.roi_id}.png"
             outline_path = output_dir / f"outline_{roi.roi_id}.png"
-            sub_video_path = output_dir / f"video_{roi.roi_id}.mp4"
+            sub_video_path = output_dir / f"video_{roi.roi_id}.webm"
             max_proj_path = output_dir / f"max_{roi.roi_id}.png"
             avg_proj_path = output_dir / f"avg_{roi.roi_id}.png"
             trace_path = output_dir / f"trace_{roi.roi_id}.json"
@@ -198,9 +198,9 @@ class TransformPipeline(argschema.ArgSchemaParser):
             sub_video = np.pad(
                     downsampled_video[:, inds[0]:inds[1], inds[2]:inds[3]],
                     ((0, 0), *pads))
-            transform_to_mp4(
+            transform_to_webm(
                     sub_video, str(sub_video_path),
-                    playback_fps, self.args['mp4_bitrate'])
+                    playback_fps, self.args['webm_bitrate'])
 
             # sub-projections
             sub_max = np.pad(

--- a/slapp/transforms/video_utils.py
+++ b/slapp/transforms/video_utils.py
@@ -46,10 +46,10 @@ def downsample_h5_video(
     return video_out
 
 
-def transform_to_mp4(video: np.ndarray, output_path: str,
-                     fps: float, bitrate: str = "192k"):
+def transform_to_webm(video: np.ndarray, output_path: str,
+                      fps: float, bitrate: str = "192k"):
     """
-    Function to transform 2p gray scale video into a mp4
+    Function to transform 2p gray scale video into a webm
     video using imageio_ffmpeg.
     Args:
         video: Video to be transformed with shape (time, row, col)
@@ -59,10 +59,16 @@ def transform_to_mp4(video: np.ndarray, output_path: str,
     Returns:
 
     """
+
+    # ffmpeg expects the video shape in width, height not row, col
+    # have to reverse shape when inputting
+    # gray8 is uint8 format
+
     writer = mpg.write_frames(output_path,
-                              video[0].shape,
-                              pix_fmt_in="gray",
-                              pix_fmt_out="gray",
+                              (video[0].shape[1], video[0].shape[0]),
+                              pix_fmt_in="gray8",
+                              pix_fmt_out="yuv420p",
+                              codec="libvpx-vp9",
                               fps=fps,
                               bitrate=bitrate)
     writer.send(None)

--- a/tests/test_rois.py
+++ b/tests/test_rois.py
@@ -1,5 +1,3 @@
-import json
-import sqlite3
 import pytest
 import numpy as np
 from scipy.sparse import coo_matrix

--- a/tests/transforms/test_transform_pipeline.py
+++ b/tests/transforms/test_transform_pipeline.py
@@ -46,7 +46,7 @@ def create_expected_manifest(experiment_id, roi_id, segmentation_run_id,
         "roi-id": roi_id,
         "source-ref": f"{save_path}/{out_dirname}/outline_{roi_id}.png",
         "roi-mask-source-ref": f"{save_path}/{out_dirname}/mask_{roi_id}.png",
-        "video-source-ref": f"{save_path}/{out_dirname}/video_{roi_id}.mp4",
+        "video-source-ref": f"{save_path}/{out_dirname}/video_{roi_id}.webm",
         "max-source-ref": f"{save_path}/{out_dirname}/max_{roi_id}.png",
         "avg-source-ref": f"{save_path}/{out_dirname}/avg_{roi_id}.png",
         "trace-source-ref": f"{save_path}/{out_dirname}/trace_{roi_id}.json"
@@ -93,7 +93,7 @@ def test_transform_pipeline(tmp_path, monkeypatch, mock_db_conn_fixture,
     mock_normalize = MagicMock(side_effect=normalize_side_effect)
     mock_imageio = MagicMock()
     mock_content_extents = MagicMock(return_value=([0, 0, 2, 2], [1, 1, 1, 1]))
-    mock_transform_to_mp4 = MagicMock()
+    mock_transform_to_webm = MagicMock()
     mock_np = MagicMock()
     mock_np.quantile = MagicMock(return_value=(0, 1))
 
@@ -103,7 +103,7 @@ def test_transform_pipeline(tmp_path, monkeypatch, mock_db_conn_fixture,
     mpatcher(name="imageio", value=mock_imageio)
     mpatcher(name="content_extents", value=mock_content_extents)
     mpatcher(name="normalize_array", value=mock_normalize)
-    mpatcher(name="transform_to_mp4", value=mock_transform_to_mp4)
+    mpatcher(name="transform_to_webm", value=mock_transform_to_webm)
     mpatcher(name="np", value=mock_np)
 
     os.environ['TRANSFORM_HASH'] = 'dummy_hash'


### PR DESCRIPTION
# Overview
The mp4 videos were showing up green and broken on Mac devices because of an unsupported codec and output pixel type.

# Completed
* The movie container has been changed to webm format
* The movie codec format has been changed from x264 to VP9
* The output pixel format has been changed from 'gray' to 'yuv420p'
* Tests were changed to support the webm format
* A small bug was fixed where ffmpeg wanted shape in length x width not row x col

# Validation
* webm files have been validated to run on Mac, Windows, and Linux and embedded into sage maker web app
* branch was used to run the entire transformation pipeline to ensure that nothing breaks during usage. The following path points to the output of the transformation pipeline for this branch `/allen/aibs/informatics/isaak/webm_transform/seg_run_id_954/20200511141506`

Below are the produced artifacts from one ROI from the video that the transformation pipeline was run (ROI 1575293)

### Video Screen Shot (ROI 1575293)
![image](https://user-images.githubusercontent.com/58192697/81725469-b9890480-943a-11ea-9f03-443537e62f3a.png)

### Average Projection (ROI 1575293)
![avg_1575293](https://user-images.githubusercontent.com/58192697/81725548-db828700-943a-11ea-8fa4-e7fd70c781f8.png)

### Max Projection (ROI 1575293)
![max_1575293](https://user-images.githubusercontent.com/58192697/81725747-26040380-943b-11ea-8cc9-4cc53504b44e.png)

### Mask (ROI 1575293)
![mask_1575293](https://user-images.githubusercontent.com/58192697/81725712-17b5e780-943b-11ea-9cb3-bb99aec70345.png)

### Outline (ROI 1575293)
![outline_1575293](https://user-images.githubusercontent.com/58192697/81725767-31efc580-943b-11ea-88ca-a93bbf0b1543.png)

### Ground Truth Job with Webm and VP9

[Ground Truth Job](https://nam12.safelinks.protection.outlook.com/?url=https%3A%2F%2Fuk2ac5ikj9.labeling.us-west-2.sagemaker.aws%2F&data=02%7C01%7C%7C92306f014b804907403a08d7ed4f965d%7C32669cd6737f4b398bddd6951120d3fc%7C0%7C1%7C637238798395243851&sdata=RutdM%2FnhliTK4i8vIM271mBNrvUP80GJTC5n4uIfwGM%3D&reserved=0)

#### Screenshot
![image](https://user-images.githubusercontent.com/58192697/81726109-b17d9480-943b-11ea-8c81-cdd1d2bc7242.png)


# Documentation

* Updated the design doc with a short description of video format and container as well as brief reasoning.

* Added a small document justifying our decisions on containers and codecs in [sharepoint](https://alleninstitute.sharepoint.com/:t:/s/Pika/EUfJzvaYDLhErMNqhWWhUrUBQuFK9rtRRV5Ey20P51crNQ?e=DIa7PV)

> Overview
> 
> This document goes over the justification of using webm containers and VP9 codec with AWS architecture. The Pika team has spent time investigating the most sustainable choice going forward and this document is intended to capture that effort.
> Problem Statement
> 
> When working with AWS we must support many different browsers, OS, and computer architectures, this makes it difficult to chose a codec for web video that is supported by all systems. All systems must support the decoding and container formats of videos or many features will break across different system configurations.
> 
> The two most common codecs used are x264 and VP9, along with their respective containers mp4 and webm. Both codec and container combos are intended to be supported cross platform among many different operating systems and hardware configurations. Pika found this to not be the absolute case as we struggled to have videos play on Mac OS devices. x264 is not always pre installed on Mac devices leaving a major support job to be completed installing x264 to maintain functionality cross platform. VP9/webm however is supported for encoding and decoding on newer versions of Mac OS, we have yet to encounter a Mac OS version not supporting the VP9 codec. It was for this reason that the Pika team decided to use V9 for encoding and webm for containers.
> 
> This choice was motivated by the use case where users have a Mac and are unable to views videos encoded using x264. VP9 and webm are both supported by Google with continual releases, making for robust efficient code. VP9 and webm are additionally open sourced in their entirety, alligning more with the Allen Institutes mission of open science. VP9 and x264 have roughly equivalent compression benchmarks with VP9 slightly outperforming x264 in compression and quality. Team Pika felt that the most robust and maintainible format in the long run was to use VP9 and webm for the reasons listed above. We are happy to discuss further with any other Allen Institute team who is considering different options.
> 
> 
> 