### PR TITLE
Added verbosity to the full instructions displayed in the SMGT web app

### DIFF
--- a/slapp/app/index.liquid.html
+++ b/slapp/app/index.liquid.html
@@ -277,11 +277,71 @@
     </classification-target>
     
     <full-instructions header="Cell Detection Instructions">
+        <h5>Objective</h5>
         <p>Decide whether the region of interest is a cell or not.</p>
-        <div>
-           <p><strong>Example: </strong></p>
-           <p><strong>Response: </strong></p>
-        </div>
+        <br>
+        <h5>Supported Browsers</h5>
+        <p>We currently only support modern Chrome and modern Firefox.
+          Support for other browsers will not be provided, use at your own
+          risk.</p>
+        <br>
+        <h5>Features</h5>
+        <ul>
+          <li><b>Traces:</b></li>
+          <ul type="square">
+            <li>Clicking the trace on the full resolution trace display
+              brings the movie to the frame you selected.</li>
+            <li>You can select a portion of the the movie to be played
+            by dragging to selection on the lower trace navigation bar.</li>
+          </ul>
+          <li><b>Movie Playback:</b></li>
+          <ul type="square">
+            <li>Click play selection once trace segment selected to play
+            that portion of the video.</li>
+            <li>Click play all to play entire video from beginning</li>
+            <li>Click speed controller to the right of play all to select
+            movie playback speed from a dropdown menu</li>
+          </ul>
+          <li><b>Movie and Image Views:</b></li>
+          <ul type="square">
+            <li>Clicking a movie or image maximizes the view of the
+              selection.</li>
+            <li>Clicking a maximized movie or image will reduce the view to
+              the original size.</li>
+          </ul>
+          <li><b>Image and Video Adjustment Controls</b></li>
+          <ul type="square">
+            <li>Toggle between hidden and shown adjustment controls by pressing
+            the button titled "Show/Hide Image Adjustment Controls"</li>
+            <li>Toggle brightness and contrast of the video by sliding the
+            labeled sliders along the tracks</li>
+            <li>Reset the brightness and contrast to default by pressing
+            the reset button under each slider</li>
+          </ul>
+        </ul>
+        <br>
+        <h5>Error Resolutions</h5>
+        <ul>
+          <li><b>Videos or Images Not Appearing:</b> If the images or video
+          do not load (do not appear in a row across the top of the
+          page) follow these steps until problem is resolved.</li>
+          <ol type="1">
+            <li>Refresh the page</li>
+            <li>Close browser entirely and shut down background process.
+              Reopen broswer and navigate back to page.</li>
+            <li>Open labeling task in different broswer, either Firefox or
+              Chrome, whichever you previously were not using.</li>
+          </ol>
+          <li><b>Required Scrolling to View all Page Elements:</b> If you find
+          yourself needing to scroll to view all page elements follow these
+          steps until the problem is resolved.</li>
+          <ol type="1">
+            <li>Check zoom level of page and reset to 100% zoom if at any other
+            zoom setting.</li>
+            <li>Open labeling task in different broswer, either Firefox or
+              Chrome, whichever you previously were not using.</li>
+          </ol>
+        </ul>
     </full-instructions>
 
     <short-instructions>

--- a/slapp/app/index.liquid.html
+++ b/slapp/app/index.liquid.html
@@ -282,11 +282,17 @@
         <br>
         <h5>Supported Browsers</h5>
         <p>We currently only support modern Chrome and modern Firefox.
-          Support for other browsers will not be provided, use at your own
-          risk.</p>
+          Support for other browsers will not be provided.</p>
         <br>
         <h5>Features</h5>
         <ul>
+          <li><b>Movie and Image Views:</b></li>
+          <ul type="square">
+            <li>Clicking a movie or image maximizes the view of the
+              selection.</li>
+            <li>Clicking a maximized movie or image will reduce the view to
+              the original size.</li>
+          </ul>
           <li><b>Traces:</b></li>
           <ul type="square">
             <li>Clicking the trace on the full resolution trace display
@@ -302,19 +308,12 @@
             <li>Click speed controller to the right of play all to select
             movie playback speed from a dropdown menu</li>
           </ul>
-          <li><b>Movie and Image Views:</b></li>
-          <ul type="square">
-            <li>Clicking a movie or image maximizes the view of the
-              selection.</li>
-            <li>Clicking a maximized movie or image will reduce the view to
-              the original size.</li>
-          </ul>
           <li><b>Image and Video Adjustment Controls</b></li>
           <ul type="square">
             <li>Toggle between hidden and shown adjustment controls by pressing
             the button titled "Show/Hide Image Adjustment Controls"</li>
-            <li>Toggle brightness and contrast of the video by sliding the
-            labeled sliders along the tracks</li>
+            <li>Toggle brightness and contrast of the video and images by
+              sliding the labeled sliders along the tracks</li>
             <li>Reset the brightness and contrast to default by pressing
             the reset button under each slider</li>
           </ul>

--- a/slapp/app/index.liquid.html
+++ b/slapp/app/index.liquid.html
@@ -346,9 +346,16 @@
     <short-instructions>
         Decide whether the region of interest is a cell or not. <br>
         <br>
-        Jump to a point in the 2p recording by clicking on the chart trace. <br>
-        To play a selected time range, click and drag on the chart or adjust
-        the navigation slider below the trace, then click "Play Selection".
+        <h5>Quick Feature Hints:</h5>
+        <ul>
+          <li>Jump to a point in the 2p recording by clicking on the chart trace.</li>
+          <li>To play a selected time range, click and drag on the chart or
+            adjust the navigation slider below the trace, then click
+            "Play Selection".</li>
+          <li>Clicking a movie or image maximizes the view of the selection.</li>
+          <li>Clicking a maximized movie or image will reduce the view to the
+            original size.</li>
+        </ul>
     </short-instructions>
   </crowd-classifier>
 </crowd-form>


### PR DESCRIPTION
# Overview
This PR adds verbosity to the our existing full instructions pane in the ground truth web app. It addresses all the points laid out in [77](https://app.zenhub.com/workspaces/allensdk-10-5c17f74db59cfb36f158db8c/issues/alleninstitute/segmentation-labeling-app/77
). These instructions will help users to understand the tools and their usages and provide some error resolutions for commonly seen errors.

# Added 
The following instructions to the ground truth app.
* What browsers we support
* Trace feature instructions
* Movie and image feature instructions
* Common errors and resolution steps

# Validation

### Screenshot of Instructions on Localhost
![image](https://user-images.githubusercontent.com/58192697/81844081-6af36d00-9503-11ea-82c6-97f3a3a86b63.png)
![image](https://user-images.githubusercontent.com/58192697/81844108-72b31180-9503-11ea-93e1-d8151376e5f4.png)

### Ground Truth job Screen and Link

![image](https://user-images.githubusercontent.com/58192697/81844753-67acb100-9504-11ea-881a-5ac2b215fdd3.png)
![image](https://user-images.githubusercontent.com/58192697/81844793-77c49080-9504-11ea-9e67-70455814e629.png)

[Ground Truth Example Job](https://nam12.safelinks.protection.outlook.com/?url=https%3A%2F%2Fuk2ac5ikj9.labeling.us-west-2.sagemaker.aws%2F&data=02%7C01%7C%7C92306f014b804907403a08d7ed4f965d%7C32669cd6737f4b398bddd6951120d3fc%7C0%7C1%7C637238798395243851&sdata=RutdM%2FnhliTK4i8vIM271mBNrvUP80GJTC5n4uIfwGM%3D&reserved=0)