### PR TITLE
Parallelize video encoding and add quality (crf) control for encoding

### DIFF
--- a/slapp/transforms/video_utils.py
+++ b/slapp/transforms/video_utils.py
@@ -1,7 +1,12 @@
+import multiprocessing
+import subprocess
+import tempfile
 from pathlib import Path
-from typing import Union
+from typing import List, Union
+
 import h5py
 import numpy as np
+
 import imageio_ffmpeg as mpg
 from slapp.transforms.array_utils import downsample_array
 
@@ -46,32 +51,130 @@ def downsample_h5_video(
     return video_out
 
 
-def transform_to_webm(video: np.ndarray, output_path: str,
-                      fps: float, bitrate: str = "192k"):
+def concat_videos(video_paths: List[str], output_path: str) -> str:
+    """Use ffmpeg to concatenate a list of videos (with the same encoding)
+    into a single video.
+
+    Parameters
+    ----------
+    video_paths : List[str]
+        A list of paths (str) for videos that should be concatenated together
+        Order of paths matters!
+    output_path : str
+        The desired output path for the concatenated video
+
+    Returns
+    -------
+    str
+        Path of concatenated video
     """
-    Function to transform 2p gray scale video into a webm
-    video using imageio_ffmpeg.
-    Args:
-        video: Video to be transformed with shape (time, row, col)
-        output_path: Output path for the transformed video
-        fps: desired fps of the output video
 
-    Returns:
+    with tempfile.NamedTemporaryFile(suffix=".txt") as concat_list_file:
+        with open(concat_list_file.name, 'w') as fp:
+            for path in video_paths:
+                fp.write(f"file '{path}'\n")
 
+        # See: https://trac.ffmpeg.org/wiki/Concatenate
+        ffmpeg_concat_cmd = [mpg.get_ffmpeg_exe(), '-y', '-f', 'concat',
+                             '-safe', '0', '-i', concat_list_file.name,
+                             '-c', 'copy', output_path]
+        subprocess.run(ffmpeg_concat_cmd)
+
+    return output_path
+
+
+def encode_video(video: np.ndarray, output_path: str,
+                 fps: float, bitrate: str = "0", crf: int = 20) -> str:
+    """Encode a video with vp9 codec via imageio-ffmpeg
+
+    Parameters
+    ----------
+    video : np.ndarray
+        Video to be encoded
+    output_path : str
+        Desired output path for encoded video
+    fps : float
+        Desired frame rate for encoded video
+    pix_fmt_out : str
+        Desired pixel format for output encoded video, by default "yuv420p"
+    bitrate : str, optional
+        Desired bitrate of output, by default "0". The default *MUST*
+        be zero in order to encode in constant quality mode. Other values
+        will result in constrained quality mode.
+    crf : int, optional
+        Desired perceptual quality of output, by default 20. Value can
+        be from 0 - 63. Lower values mean better quality (but bigger video
+        sizes).
+
+    Returns
+    -------
+    str
+        Output path of the encoded video
     """
 
-    # ffmpeg expects the video shape in width, height not row, col
-    # have to reverse shape when inputting
-    # gray8 is uint8 format
+    # ffmpeg expects video shape in terms of: (width, height)
+    video_shape = (video[0].shape[1], video[0].shape[0])
 
     writer = mpg.write_frames(output_path,
-                              (video[0].shape[1], video[0].shape[0]),
+                              video_shape,
                               pix_fmt_in="gray8",
                               pix_fmt_out="yuv420p",
                               codec="libvpx-vp9",
                               fps=fps,
-                              bitrate=bitrate)
-    writer.send(None)
+                              bitrate=bitrate,
+                              output_params=["-crf", str(crf)])
+
+    writer.send(None)  # Seed ffmpeg-imageio writer generator
     for frame in video:
         writer.send(frame)
     writer.close()
+
+    return output_path
+
+
+def transform_to_webm(video: np.ndarray, output_path: str,
+                      fps: float, ncpu: int, bitrate: str = "0",
+                      crf: int = 20) -> str:
+    """Function to transform 2p gray scale video into a webm
+    video using imageio_ffmpeg.
+
+    Parameters
+    ----------
+    video : np.ndarray
+        Video to be transformed with shape (time, row, col)
+    output_path : str
+        Output path for the transformed video
+    fps : float
+        Desired frames per second (fps) of the output video
+    ncpu : int
+        Degree of parallelization desired for encoding. Video will be
+        split into 'ncpu' parts and each part will be encoded in parallel.
+    bitrate : str, optional
+        Desired bitrate of output, by default "0". The default *MUST*
+        be zero in order to encode in constant quality mode.
+    crf : int, optional
+        Desired perceptual quality of output, by default 20. Value can
+        be from 0 - 63. Lower values mean better quality.
+
+    Returns
+    -------
+    str
+        Output path of the encoded video
+    """
+
+    split_video = np.array_split(video, ncpu)
+    split_output_paths = [tempfile.NamedTemporaryFile(suffix=f"_{i}.webm")
+                          for i in range(ncpu)]
+
+    mp_pool_args = [(vid, outpath.name, fps, bitrate, crf)
+                    for vid, outpath in zip(split_video, split_output_paths)]
+
+    with multiprocessing.Pool(ncpu) as pool:
+        encode_results = pool.starmap(encode_video, mp_pool_args)
+
+    concat_output = concat_videos(encode_results, output_path)
+
+    for sop in split_output_paths:
+        sop.close()
+
+    return concat_output

--- a/tests/transforms/test_video_utils.py
+++ b/tests/transforms/test_video_utils.py
@@ -1,7 +1,10 @@
-import pytest
-import numpy as np
-import imageio
+from collections import defaultdict
+
 import h5py
+import numpy as np
+import pytest
+
+import imageio_ffmpeg as mpg
 import slapp.transforms.video_utils as transformations
 
 
@@ -39,39 +42,141 @@ def test_video_downsample(
     assert np.array_equal(downsampled_video, expected)
 
 
-@pytest.mark.parametrize("video_size", [((16, 32)),
-                                        ((16, 16))])
-def test_webm_conversion(video_size, tmp_path):
-    # make the test video a size of at least 16x16
-    # otherwise, need to mess with macro_block_size arg
-    nframes_written = 25
-    output_path = tmp_path / 'video.mp4'
-    fps = 30
-    rng = np.random.default_rng(0)
-    video = np.array(
-            [rng.integers(0, 256, size=video_size, dtype='uint8')
-             for i in range(nframes_written)])
+def compare_videos(encoded_video_path: str, expected_video: np.ndarray):
+    """Compare an encoded video with its original source"""
 
-    transformations.transform_to_webm(video=video,
-                                      output_path=output_path.as_posix(),
-                                      fps=fps),
+    reader = mpg.read_frames(encoded_video_path,
+                             pix_fmt="gray8",
+                             bits_per_pixel=8)
+    meta = reader.__next__()
+    obt_nframes = int(np.round(meta['duration'] * meta['fps']))
 
-    reader = imageio.get_reader(output_path.as_posix(), mode='I', fps=fps,
-                                pixelformat="yuv420p")
-    meta = reader.get_meta_data()
-    nframes_read = int(np.round(meta['duration'] * meta['fps']))
+    assert obt_nframes == len(expected_video)
 
-    assert nframes_read == nframes_written
+    obt_frames = []
+    for frame in reader:
+        parsed_frame = np.frombuffer(frame, dtype='uint8')
+        parsed_frame = parsed_frame.reshape(meta["size"][::-1])
+        obt_frames.append(parsed_frame)
+    obt_video = np.array(obt_frames)
 
-    # size is reversed coming from ffmpeg they use (width x height)
-    # not (row x col)
-    read_video = np.zeros((nframes_read, meta['size'][1], meta['size'][0]),
-                          dtype='uint8')
-    for i in range(nframes_read):
-        read_video[i] = reader.get_data(i)[:, :, 0]
-    reader.close()
-
-    assert read_video.shape == video.shape
+    assert obt_video.shape == expected_video.shape
     # the default settings for imageio-ffmpeg are not lossless
     # so can't test for exact match
-    np.testing.assert_allclose(read_video, video, atol=25)
+    np.testing.assert_allclose(obt_video, expected_video, atol=20)
+
+
+@pytest.fixture
+def raw_video_fixture(request):
+    video_shape = request.param.get('video_shape', (16, 32))
+    nframes = request.param.get('nframes', 25)
+    fps = request.param.get('fps', 30)
+    rng_seed = request.param.get('rng_seed', 0)
+
+    rng = np.random.default_rng(rng_seed)
+
+    raw_video = [rng.integers(0, 256, size=video_shape, dtype='uint8')
+                 for _ in range(nframes)]
+
+    result = {}
+    result["raw_video"] = np.array(raw_video)
+    result["fps"] = fps
+    result["nframes"] = nframes
+
+    return result
+
+
+@pytest.mark.parametrize("raw_video_fixture", [
+    # make the test video a size of at least 16x16
+    # otherwise, need to mess with macro_block_size arg
+    ({"video_shape": (16, 16)}),
+
+    ({"video_shape": (32, 16)})
+], indirect=["raw_video_fixture"])
+def test_encode_video(raw_video_fixture, tmp_path):
+    output_path = tmp_path / 'test_video.webm'
+
+    fps = raw_video_fixture["fps"]
+    expected_video = raw_video_fixture["raw_video"]
+
+    transformations.encode_video(video=expected_video,
+                                 output_path=output_path.as_posix(),
+                                 fps=fps),
+
+    compare_videos(output_path, expected_video)
+
+
+@pytest.fixture
+def encoded_videos_fixture(request, tmp_path):
+    num_videos = request.param.get('num_videos', 2)
+    video_shape = request.param.get('video_shape', (32, 32))
+    nframes = request.param.get('nframes', 30)
+    fps = request.param.get('fps', 30)
+
+    rng = np.random.default_rng(0)
+    test_videos = defaultdict(list)
+
+    for i in range(num_videos):
+        data = np.array([rng.integers(0, 256, size=video_shape, dtype='uint8')
+                         for _ in range(nframes)])
+
+        test_video_path = tmp_path / f"test_video_{i}.webm"
+        transformations.encode_video(video=data,
+                                     output_path=test_video_path.as_posix(),
+                                     fps=fps)
+
+        test_videos['raw_data'].append(data)
+        test_videos['encoded_videos'].append(test_video_path)
+
+    return test_videos
+
+
+@pytest.mark.parametrize("encoded_videos_fixture", [
+    ({"num_videos": 2,
+      "video_shape": (16, 16),
+      "nframes": 30,
+      "fps": 30}),
+
+    ({"num_videos": 8,
+      "video_shape": (32, 16)})
+], indirect=["encoded_videos_fixture"])
+def test_concat_videos(tmp_path, encoded_videos_fixture):
+    output_path = tmp_path / 'test_concatted_video.webm'
+
+    expected_data = np.concatenate(encoded_videos_fixture['raw_data'])
+    video_paths = encoded_videos_fixture['encoded_videos']
+
+    transformations.concat_videos(video_paths=video_paths,
+                                  output_path=output_path)
+
+    compare_videos(output_path, expected_data)
+
+
+@pytest.mark.parametrize("raw_video_fixture, ncpu", [
+    ({"video_shape": (16, 16),
+      "nframes": 45},
+
+     1),
+
+    ({"video_shape": (16, 16),
+      "nframes": 90},
+
+     2),
+
+    ({"video_shape": (32, 16),
+      "nframes": 90},
+
+     4)
+], indirect=["raw_video_fixture"])
+def test_transform_to_webm(raw_video_fixture, tmp_path, ncpu):
+    output_path = tmp_path / 'test_video.webm'
+
+    fps = raw_video_fixture["fps"]
+    expected_video = raw_video_fixture["raw_video"]
+
+    transformations.transform_to_webm(video=expected_video,
+                                      output_path=output_path,
+                                      fps=fps,
+                                      ncpu=ncpu)
+
+    compare_videos(output_path, expected_video)


### PR DESCRIPTION
This commit aims to solve the problem of slow VP9 encoding by
implementing parallelization of the webm transform step. Videos
are split into chunks by time and separately encoded via
multiprocessing before being stitched back together with ffmpeg.

This commit also adds the ability to specify a desired perceptual
quality for the encoded video.

The default encoding strategy has been changed from
"constant bitrate" to "constant quality". For more details please
see: https://trac.ffmpeg.org/wiki/Encode/VP9

Relates to: #94, #95

------
Still TODO:

Run updated pipeline with following `ophys_experiment_ids`:
- [x] 850517352
- [x] 850517344
- [x] 853988430
- [x] 856123119
- [x] 854759894

- [x] If ophys_experiment_id videos look okay, try spinning up entire labeling app

- [x] Squash commits when everything looks good