### PR TITLE
Feature/multi experiment upload

### DIFF
--- a/slapp/transfers/upload.py
+++ b/slapp/transfers/upload.py
@@ -69,12 +69,15 @@ class LabelDataUploader(argschema.ArgSchemaParser):
         self.logger.info(f"bucket destination is {uri}")
 
         # upload the per-experiment objects
-        full_video_paths = np.unique([m['full-video-source-ref']
-                                     for m in manifests])
+        full_video_paths, uindex = np.unique(
+                [m['full-video-source-ref'] for m in manifests],
+                return_index=True)
+        experiment_ids = [manifests[ui]['experiment-id'] for ui in uindex]
         self.logger.info(f"{full_video_paths.size} full videos to upload")
         s3_full_videos = {}
-        for video_path in full_video_paths:
-            object_key = prefix + "/" + pathlib.PurePath(video_path).name
+        for eid, video_path in zip(experiment_ids, full_video_paths):
+            object_key = prefix + "/" + f"{eid}_"
+            object_key += pathlib.PurePath(video_path).name
             s3_full_video = utils.upload_file(
                     video_path,
                     self.args['s3_bucket_name'],

--- a/tests/transfers/test_upload.py
+++ b/tests/transfers/test_upload.py
@@ -62,7 +62,10 @@ def test_LabelDataUploader(mock_db_conn_fixture, bucket, timestamp):
     files_in_db = []
     for k, v in in_local_postgres.items():
         if not isinstance(v, int):
-            files_in_db.append(os.path.basename(v))
+            special_prefix = ''
+            if k == 'full-video-source-ref':
+                special_prefix = f"{in_local_postgres['experiment-id']}_"
+            files_in_db.append(special_prefix + os.path.basename(v))
 
     # s3 should have all the files, + 1 manifest
     assert len(files_in_s3) == (len(files_in_db) + 1)


### PR DESCRIPTION
The uploader was only set to upload a single experiment at a time. This was generally how we were creating manifests during development. Now that we're mixing experiments in production, this failed. This PR allows for multi-experiment uploads and continues to avoid re-uploads of shared full video files. Full video object "basenames" on s3 are now prefixed with an experiment id to avoid on-s3 filename collisions.
```
$ python -m slapp.transfers.upload --input_json upload_input.json
INFO:LabelDataUploader:Requesting 1000 roi manifests from postgres
INFO:LabelDataUploader:bucket destination is s3://prod.slapp.alleninstitute.org/2-line 2-project/20200520051838
INFO:LabelDataUploader:126 full videos to upload
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
...
```
![image](https://user-images.githubusercontent.com/32312979/82445711-2b280a80-9a5a-11ea-824b-bf24bc0732fd.png)

and a snipped downloaded manifest of a short 4-experiment upload after this change:
```
{"experiment-id": 875786885, "roi-id": 1577769, ... "full-video-source-ref": "s3://prod.slapp.alleninstitute.org/trial/20200520050950/875786885_full_video.webm"}
{"experiment-id": 868870085, "roi-id": 1576911, ... "full-video-source-ref": "s3://prod.slapp.alleninstitute.org/trial/20200520050950/868870085_full_video.webm"}
{"experiment-id": 871196369, "roi-id": 1580253, ... "full-video-source-ref": "s3://prod.slapp.alleninstitute.org/trial/20200520050950/871196369_full_video.webm"}
{"experiment-id": 853988446, "roi-id": 1576223, ... "full-video-source-ref": "s3://prod.slapp.alleninstitute.org/trial/20200520050950/853988446_full_video.webm"}
```
