### PR TITLE
adds ThreadPool parallelization to uploader

### DIFF
--- a/slapp/transfers/upload.py
+++ b/slapp/transfers/upload.py
@@ -111,7 +111,7 @@ class LabelDataUploader(argschema.ArgSchemaParser):
 
         # NOTE a reason to use ThreadPool instead of Pool is that
         # moto testing does not work with a process-based pool
-        # multiprocessing docs do not detail ThreadPool: 
+        # multiprocessing docs do not detail ThreadPool:
         # https://github.com/python/cpython/blob/eb0d359b4b0e14552998e7af771a088b4fd01745/Lib/multiprocessing/pool.py#L918 # noqa
         with ThreadPool(self.args['parallelization']) as pool:
             results = pool.starmap(utils.upload_file, args)


### PR DESCRIPTION
The uploader was single-threaded. When uploading 1000 ROIs (129 experiments, 7133 objects, 158GB) it took 4.5 hours.

This adds a `ThreadPool` capability to try to speed up the upload through parallel threads. It's up to the user to determine what works best. The following is a likely non-optimal example.

The first 69 full movies of the 1000-ROI upload took 2000 seconds. In a truncated upload of 100 ROIs (comprising 69 full movies) the full movies uploaded in 945 seconds. This was with `--parallelization 10`. Probably a setting of `2` or `3` would hit the same network bottleneck somewhere.
Edit: all file uploads are round-tripped to disk. The 2x-only speedup might reflect some disk i/o bottleneck as well.