### PR TITLE
Feature/faster upload validation

### DIFF
--- a/slapp/transfers/upload.py
+++ b/slapp/transfers/upload.py
@@ -111,7 +111,7 @@ class LabelDataUploader(argschema.ArgSchemaParser):
 
         # NOTE a reason to use ThreadPool instead of Pool is that
         # moto testing does not work with a process-based pool
-        # multiprocessing docs do not detail ThreadPool: 
+        # multiprocessing docs do not detail ThreadPool:
         # https://github.com/python/cpython/blob/eb0d359b4b0e14552998e7af771a088b4fd01745/Lib/multiprocessing/pool.py#L918 # noqa
         with ThreadPool(self.args['parallelization']) as pool:
             results = pool.starmap(utils.upload_file, args)


### PR DESCRIPTION
Easier to review if #111 is approved and merged first.

#111 improved upload speed by about 2x through parallelization. We considered that further improvements in speed could come from eliminating the file i/o incorporated in the roundtrip validation. This PR makes that roundtrip optional and off by default. When off, it is replaced by just checking whether an object exists.
This improved speed by another 2x. This indicates that disk i/o is not a significant contributor, but, that there is some network bottleneck we are hitting. Without round-tripping the objects, we have 2x less traffic.
I will run another 1000 ROI upload to check this. When writing, I encountered some latency in objects appearing on S3. I added retries and delays, and hope this longer test will  confirm that these default settings are sufficiently robust.