### PR TITLE
Feature/botocore upload

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ scipy
 pg8000
 pytest
 pytest-cov
+botocore
 boto3
 moto
 ipywidgets

--- a/slapp/transfers/upload.py
+++ b/slapp/transfers/upload.py
@@ -225,7 +225,7 @@ class LabelDataUploader(argschema.ArgSchemaParser):
         self.output(
                 {
                     'successful_uploads': success,
-                    'failed_uploads': success,
+                    'failed_uploads': failed,
                     'local_s3_manifest_copy':
                         self.args['local_s3_manifest_copy']
                         },

--- a/slapp/transfers/upload.py
+++ b/slapp/transfers/upload.py
@@ -111,7 +111,7 @@ class LabelDataUploader(argschema.ArgSchemaParser):
 
         # NOTE a reason to use ThreadPool instead of Pool is that
         # moto testing does not work with a process-based pool
-        # multiprocessing docs do not detail ThreadPool: 
+        # multiprocessing docs do not detail ThreadPool:
         # https://github.com/python/cpython/blob/eb0d359b4b0e14552998e7af771a088b4fd01745/Lib/multiprocessing/pool.py#L918 # noqa
         with ThreadPool(self.args['parallelization']) as pool:
             results = pool.starmap(utils.upload_file, args)

--- a/slapp/transfers/upload.py
+++ b/slapp/transfers/upload.py
@@ -90,7 +90,8 @@ class LabelDataUploader(argschema.ArgSchemaParser):
         self.logger.name = type(self).__name__
 
         # unique timestamp for this invocation
-        self.timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+        time_start = datetime.datetime.now()
+        self.timestamp = time_start.strftime('%Y%m%d%H%M%S')
 
         # get the specified per-ROI manifests
         if self.args["roi_manifests_ids"]:
@@ -230,6 +231,11 @@ class LabelDataUploader(argschema.ArgSchemaParser):
                         self.args['local_s3_manifest_copy']
                         },
                 indent=2)
+
+        time_end = datetime.datetime.now()
+        self.logger.info("upload job\n"
+                         f"started : {time_start.isoformat()}\n"
+                         f"ended   : {time_end.isoformat()} ")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/slapp/transfers/upload.py
+++ b/slapp/transfers/upload.py
@@ -1,6 +1,5 @@
 import argschema
 import datetime
-import tempfile
 import slapp.transfers.utils as utils
 import slapp.utils.query_utils as query_utils
 import numpy as np
@@ -8,6 +7,7 @@ import pathlib
 import jsonlines
 from multiprocessing.pool import ThreadPool
 from functools import partial
+import marshmallow as mm
 
 
 class UploadSchema(argschema.ArgSchema):
@@ -42,10 +42,46 @@ class UploadSchema(argschema.ArgSchema):
         required=False,
         default=1,
         description="Number of parallel processes to use for uploading.")
+    client_config = argschema.fields.Dict(
+        required=False,
+        missing={'retries': {'mode': 'standard', 'max_attempts': 10}},
+        description=("passed as kwargs to botocore.config.Config() for "
+                     "client configuration."))
+    local_s3_manifest_copy = argschema.fields.OutputFile(
+        required=False,
+        default=None,
+        allow_none=True,
+        description=("file to be written to S3 as overall manifest, "
+                     "saved locally. If path not provided, will default "
+                     "to <timestamp>_s3_manifest.jsonl in output_json dir"))
+
+    @mm.pre_load
+    def set_local_manifest_path(self, data, **kwargs):
+        if data['local_s3_manifest_copy'] is None:
+            timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S')
+            data['local_s3_manifest_copy'] = str(
+                    pathlib.PurePath(data['output_json']).parent /
+                    f"{timestamp}_s3_manifest.jsonl")
+        return data
+
+
+class ResponseSchema(argschema.schemas.DefaultSchema):
+    file_name = argschema.fields.InputFile(required=True)
+    bucket = argschema.fields.Str(required=True)
+    key = argschema.fields.Str(required=True)
+    response = argschema.fields.Dict(required=True)
+
+
+class UploadOutputSchema(argschema.ArgSchema):
+    responses = argschema.fields.List(
+        argschema.fields.Nested(ResponseSchema),
+        required=True)
+    local_s3_manifest_copy = argschema.fields.OutputFile(required=True)
 
 
 class LabelDataUploader(argschema.ArgSchemaParser):
     default_schema = UploadSchema
+    default_output_schema = UploadOutputSchema
 
     def run(self, db_conn: query_utils.DbConnection):
         self.logger.name = type(self).__name__
@@ -93,7 +129,7 @@ class LabelDataUploader(argschema.ArgSchemaParser):
         uri = utils.s3_uri(self.args['s3_bucket_name'], prefix)
         self.logger.info(f"bucket destination is {uri}")
 
-        # upload the per-experiment objects
+        # find unique experiments and full videos
         full_video_paths, uindex = np.unique(
                 [m['full-video-source-ref'] for m in manifests],
                 return_index=True)
@@ -104,46 +140,74 @@ class LabelDataUploader(argschema.ArgSchemaParser):
         for eid, video_path in zip(experiment_ids, full_video_paths):
             object_key = prefix + "/" + f"{eid}_"
             object_key += pathlib.PurePath(video_path).name
-            args.append((
-                video_path,
-                self.args['s3_bucket_name'],
-                object_key))
+            args.append({
+                'file_name': video_path,
+                'bucket': self.args['s3_bucket_name'],
+                'key': object_key})
+        chunked_args = [
+                (
+                    utils.ConfiguredUploadClient(**self.args['client_config']),
+                    i.tolist())
+                for i in np.array_split(args, self.args['parallelization'])]
+
+        # track every server response for potential cleanup operations
+        upload_responses = []
 
         # NOTE a reason to use ThreadPool instead of Pool is that
         # moto testing does not work with a process-based pool
         # multiprocessing docs do not detail ThreadPool:
         # https://github.com/python/cpython/blob/eb0d359b4b0e14552998e7af771a088b4fd01745/Lib/multiprocessing/pool.py#L918 # noqa
         with ThreadPool(self.args['parallelization']) as pool:
-            results = pool.starmap(utils.upload_file, args)
-        s3_full_videos = {e: uri for e, uri in zip(experiment_ids, results)}
+            results = pool.starmap(utils.upload_files, chunked_args)
+        results = [i for r in results for i in r]
+        s3_full_videos = {e: utils.s3_uri(r['bucket'], r['key'])
+                          for e, r in zip(experiment_ids, results)}
+        upload_responses.extend([r for r in results])
 
         # upload the per-ROI manifests
         s3_manifests = []
         upload_partial = partial(
                 utils.upload_manifest_contents,
+                utils.ConfiguredUploadClient(**self.args['client_config']),
                 skip_keys=['full-video-source-ref'])
         args = []
         for manifest in manifests:
             args.append((manifest, self.args['s3_bucket_name'], prefix))
         with ThreadPool(self.args['parallelization']) as pool:
-            s3_manifests = pool.starmap(upload_partial, args)
+            results = pool.starmap(upload_partial, args)
+        s3_manifests, responses = list(zip(*results))
+        for r in responses:
+            upload_responses.extend(r)
 
         for s3_manifest in s3_manifests:
             s3_manifest['full-video-source-ref'] = \
                     s3_full_videos[s3_manifest['experiment-id']]
 
         # upload the manifest
-        tfile = tempfile.NamedTemporaryFile()
-        utils.manifest_file_from_jsons(tfile.name, s3_manifests)
+        utils.manifest_file_from_jsons(
+                self.args['local_s3_manifest_copy'],
+                s3_manifests)
+        self.logger.info("wrote local s3 manifest copy "
+                         f"{self.args['local_s3_manifest_copy']}")
         # NOTE: the docs for SageMaker GroundTruth specify a JSON Lines format
         # but, throws an error with the .jsonl extension
         # setting here to .json extension to resolve the error.
-        s3_manifest = utils.upload_file(
-                tfile.name,
+        result = utils.upload_file(
+                utils.ConfiguredUploadClient(**self.args['client_config']),
+                self.args['local_s3_manifest_copy'],
                 self.args['s3_bucket_name'],
                 key=prefix + "/manifest.json")
-        self.logger.info(f"uploaded {s3_manifest}")
-        tfile.close()
+        self.logger.info(
+                f"uploaded {utils.s3_uri(result['bucket'], result['key'])}")
+        upload_responses.append(result)
+
+        self.output(
+                {
+                    'responses': upload_responses,
+                    'local_s3_manifest_copy':
+                        self.args['local_s3_manifest_copy']
+                        },
+                indent=2)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/transfers/test_transfer_utils.py
+++ b/tests/transfers/test_transfer_utils.py
@@ -18,9 +18,23 @@ def local_file(tmpdir_factory):
 
 
 @pytest.fixture(scope='module')
+def local_files(tmpdir_factory):
+    fdir = tmpdir_factory.mktemp("files")
+    files = []
+    for i in range(5):
+        fn = fdir.join(f"test_multiple_{i}.txt")
+        with open(fn, "w") as fp:
+            fp.write("contents")
+        files.append(str(fn))
+    yield files
+
+
+@pytest.fixture(scope='module')
 def local_manifest(tmpdir_factory):
     tdir = tmpdir_factory.mktemp("manifest_files")
     manifest = {}
+    manifest['experiment-id'] = 12345
+    manifest['roi-id'] = 98765
     for i in range(3):
         fname = tdir.join(f"test{i}.txt")
         with open(fname, "w") as fp:
@@ -60,63 +74,78 @@ def list_of_dicts():
     yield jsons
 
 
-@pytest.mark.parametrize("expected", [True, False])
-def test_object_exists(local_file, bucket, expected):
-    if expected:
-        key = "object/exists/test/" + pathlib.PurePath(local_file).name
-        utils.upload_file(local_file, bucket, key=key)
-    else:
-        key = "object/does/not/exist"
-
-    exists = utils.object_exists(bucket, key)
-    assert exists == expected
-
-
-def test_local_s3_compare(local_file, bucket, tmpdir_factory):
-    key = "mykey"
-    utils.upload_file(local_file, bucket, key=key)
-
-    # object and file are same
-    assert utils.local_s3_compare(local_file, bucket, key)
-
-    # object does not exist in bucket
-    with pytest.raises(utils.S3TransferException):
-        utils.local_s3_compare(local_file, bucket, "not/a/key")
-
-    # bucket object and file are different
-    tfile = tmpdir_factory.mktemp('compare_stuff').join("junk.txt")
-    with open(str(tfile), "w") as fp:
-        fp.write("junk contents")
-    with pytest.raises(utils.S3TransferException):
-        utils.local_s3_compare(str(tfile), bucket, key)
-
-
-@pytest.mark.parametrize("key", ["abc/temp.csv", None])
+@pytest.mark.parametrize("key", ["abc/temp.csv"])
 def test_upload_file(local_file, bucket, key):
-    bucket_path = utils.upload_file(local_file, bucket, key=key)
+    client = utils.ConfiguredUploadClient()
+    result = utils.upload_file(client, local_file, bucket, key=key)
 
-    if key is None:
-        key = pathlib.PurePath(local_file).name
-    expected = f"s3://{bucket}/{key}"
-    assert bucket_path == expected
+    assert result['file_name'] == local_file
+    assert result['bucket'] == bucket
+    assert result['key'] == key
+    assert isinstance(result['response'], dict)
+    assert result['response']['ResponseMetadata']['HTTPStatusCode'] == 200
 
 
-@pytest.mark.parametrize("prefix", "abc/datetime")
+def test_upload_files(local_files, bucket):
+    client = utils.ConfiguredUploadClient()
+    upload_file_args = []
+    keys = []
+    for local_file in local_files:
+        keys.append("some/prefix/" + pathlib.PurePath(local_file).name)
+        upload_file_args.append(
+                {
+                    'file_name': local_file,
+                    'bucket': bucket,
+                    'key': keys[-1]
+                    })
+    results = utils.upload_files(client, upload_file_args)
+
+    for local_file, key, result in zip(local_files, keys, results):
+        print(result)
+        assert result['file_name'] == local_file
+        assert result['bucket'] == bucket
+        assert result['key'] == key
+        assert isinstance(result['response'], dict)
+        assert result['response']['ResponseMetadata']['HTTPStatusCode'] == 200
+
+
+@pytest.mark.parametrize("skip_keys", [[], ["key0"]])
+@pytest.mark.parametrize("prefix", ["abc/datetime"])
 def test_upload_manifest_contents(
-        local_manifest, bucket, prefix):
-    s3_manifest = utils.upload_manifest_contents(
+        local_manifest, bucket, prefix, skip_keys):
+    client = utils.ConfiguredUploadClient()
+    s3_manifest, responses = utils.upload_manifest_contents(
+            client,
             local_manifest,
             bucket,
-            prefix)
+            prefix,
+            skip_keys=skip_keys)
 
     vbase = f"s3://{bucket}/{prefix}/"
     expected = {}
     for k, v in local_manifest.items():
-        expected[k] = vbase + pathlib.PurePath(v).name
+        if k in ['experiment-id', 'roi-id']:
+            expected[k] = v
+        else:
+            expected[k] = vbase + pathlib.PurePath(v).name
+
+    for sk in skip_keys:
+        assert sk not in s3_manifest.keys()
+        expected.pop(sk)
 
     assert(set(list(s3_manifest.keys())) == set(list(expected.keys())))
     for key in expected.keys():
         assert (s3_manifest[key] == expected[key])
+
+    uploaded_objs = {f"s3://{r['bucket']}/{r['key']}" for r in responses}
+    manifest_objs = {v for k, v in s3_manifest.items()
+                     if k not in ['experiment-id', 'roi-id']}
+
+    assert uploaded_objs == manifest_objs
+
+    for r in responses:
+        assert isinstance(r, dict)
+        assert r['response']['ResponseMetadata']['HTTPStatusCode'] == 200
 
 
 def test_manifest_file_from_jsons(list_of_dicts, tmpdir_factory):

--- a/tests/transfers/test_upload.py
+++ b/tests/transfers/test_upload.py
@@ -1,10 +1,11 @@
 import pytest
 import boto3
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from moto import mock_s3
 import os
 import slapp.transfers.upload as up
 import json
+import botocore
 
 
 @pytest.fixture
@@ -58,9 +59,49 @@ def mock_manifest(tmpdir_factory):
 def bucket():
     with mock_s3():
         bucket_name = 'mybucket'
+        boto3.setup_default_session()
         conn = boto3.resource('s3')
         conn.create_bucket(Bucket=bucket_name)
         yield bucket_name
+
+
+orig = botocore.client.BaseClient._make_api_call
+
+
+def mock_make_api_call(self, operation_name, kwarg):
+    if operation_name == 'PutObject':
+        response = {
+                    'ResponseMetadata': {
+                        'HTTPStatusCode': 500
+                        }}
+        return response
+    return orig(self, operation_name, kwarg)
+
+
+def test_failed_upload(mock_db_conn_fixture, bucket, tmp_path, mock_manifest):
+    """makes all put_objects return HTTPStatusCode != 200 to check that
+    the output_json logs them all as failed uploads
+    """
+    output_json_path = tmp_path / "output.json"
+    args = {
+            's3_bucket_name': bucket,
+            'prefix': 'abc/def',
+            'output_json': str(output_json_path),
+            'manifest_file': mock_manifest,
+            }
+    with patch(
+            'botocore.client.BaseClient._make_api_call',
+            mock_make_api_call):
+        ldu = up.LabelDataUploader(input_data=args, args=[])
+        ldu.run(mock_db_conn_fixture)
+
+    with open(output_json_path, 'r') as f:
+        j = json.load(f)
+    assert 'successful_uploads' in j
+    assert 'failed_uploads' in j
+    assert 'local_s3_manifest_copy' in j
+    assert len(j['failed_uploads']) == 8
+    assert len(j['successful_uploads']) == 0
 
 
 @pytest.mark.parametrize("timestamp,manifest", [
@@ -117,3 +158,12 @@ def test_LabelDataUploader(mock_db_conn_fixture, bucket, timestamp, manifest,
     for f in files_in_s3:
         dname = os.path.dirname(f)
         assert dname == expected
+
+    # check the output json
+    with open(output_json_path, 'r') as f:
+        j = json.load(f)
+    assert 'successful_uploads' in j
+    assert 'failed_uploads' in j
+    assert 'local_s3_manifest_copy' in j
+    assert len(j['failed_uploads']) == 0
+    assert len(j['successful_uploads']) == 8

--- a/tests/transfers/test_upload.py
+++ b/tests/transfers/test_upload.py
@@ -1,6 +1,6 @@
 import pytest
-from unittest.mock import MagicMock
 import boto3
+from unittest.mock import MagicMock
 from moto import mock_s3
 import os
 import slapp.transfers.upload as up
@@ -66,13 +66,16 @@ def bucket():
 @pytest.mark.parametrize("timestamp,manifest", [
     (True, None),
     (False, None),
-    (False, True)])
+    (False, True)
+    ])
 def test_LabelDataUploader(mock_db_conn_fixture, bucket, timestamp, manifest,
-                           mock_manifest):
+                           mock_manifest, tmp_path):
+    output_json_path = tmp_path / "output.json"
     args = {
             's3_bucket_name': bucket,
             'timestamp': timestamp,
             'prefix': 'abc/def',
+            'output_json': str(output_json_path)
             }
     if manifest:
         args.update({"manifest_file": mock_manifest})


### PR DESCRIPTION
includes #111, replaces #113

## Improvements to uploader
* adds `ThreadPool` parallelization for faster uploads
* eliminates round-trip to disk to gain speed from less network usage and less disk usage
* abaondons `boto3.client("s3")` in favor of `botocore.client` called with a `botocore.config.Config` object for exposure of many more options including (1) retry control and (2) checksum checks.
* `upload_file` no longer creates a client, but now takes a client object as an arg.
* new `upload_files` helper function.
* new cleanup attempt at the end of the transfer, for any failed uploads.
* transfer does not die on failed uploads. In the event of a failed upload, a warning is show.
* adds a validated output_json as an extensive log which can be used later to manually correct any failures.
* local copy of on-s3 manifest is no longer a tempfile and is logged in the output_json

## example output_json:
```
{
  "log_level": "ERROR",
  "local_s3_manifest_copy": "logs/20200522142137_s3_manifest.jsonl",
  "failed_uploads": [],
  "succsessful_uploads": [
    {
      "response": {
        "ResponseMetadata": {
          "RequestId": "40764879149C6C5C",
          "HostId": "e7Keu9QRa25sMqLt1p6FOmfjeKzLYA0/LgDpf6idmrAtLsH99YJK0jr6VXNAzi6SBOI0ZLRMyvg=",
          "HTTPStatusCode": 200,
          "HTTPHeaders": {
            "x-amz-id-2": "e7Keu9QRa25sMqLt1p6FOmfjeKzLYA0/LgDpf6idmrAtLsH99YJK0jr6VXNAzi6SBOI0ZLRMyvg=",
            "x-amz-request-id": "40764879149C6C5C",
            "date": "Fri, 22 May 2020 21:21:40 GMT",
            "etag": "\"4be81d812a3cf8256a1e62e2cef3ca2b\"",
            "content-length": "0",
            "server": "AmazonS3"
          },
          "RetryAttempts": 1
        },
        "ETag": "\"4be81d812a3cf8256a1e62e2cef3ca2b\""
      },
      "file_name": "/allen/aibs/informatics/labeling_artifacts/seg_run_id_1042/20200519161125/full_video.webm",
      "key": "parallel-upload-test/20200522142137/865798247_full_video.webm",
      "bucket": "prod.slapp.alleninstitute.org"
    },
   ...
  ]
}
```

## validation
with this branch, 1000 ROIs uploaded in 40 minutes (previously 270 minutes) with no failures (parallelization = 4)
```
$ python -m slapp.transfers.upload --input_json upload_input.json --output_json ./logs/output.json
WARNING:root:setting Dict fields not supported from argparse
INFO:LabelDataUploader:Requesting 1000 roi manifests from postgres
INFO:LabelDataUploader:bucket destination is s3://prod.slapp.alleninstitute.org/robustness-check/20200522152030
INFO:LabelDataUploader:126 full videos to upload
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
INFO:LabelDataUploader:wrote local s3 manifest copy logs/20200522152030_s3_manifest.jsonl
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
INFO:LabelDataUploader:uploaded s3://prod.slapp.alleninstitute.org/robustness-check/20200522152030/manifest.json
INFO:LabelDataUploader:7127 uploads succeeded
INFO:LabelDataUploader:upload job
started : 2020-05-22T15:20:30.070472
ended   : 2020-05-22T16:00:43.965029 
```
