### PR TITLE
Feature/merge sage maker outputs

### DIFF
--- a/slapp/transfers/utils.py
+++ b/slapp/transfers/utils.py
@@ -38,7 +38,8 @@ def read_jsonlines(
     file, given a uri (s3 uri or local filepath).
     """
     if str(uri).startswith("s3://"):
-        data = s3_get_object(uri)["Body"].iter_lines(chunk_size=8192)    # The lines can be big        # noqa
+        # chunked because the lines can be big
+        data = s3_get_object(uri)["Body"].iter_lines(chunk_size=8192)
         reader = jsonlines.Reader(data)
     else:
         data = open(uri, "rb")

--- a/slapp/utils/merge_utils.py
+++ b/slapp/utils/merge_utils.py
@@ -198,7 +198,6 @@ def merge_outputs(src_uris: List[Union[str, Path]],
     for record in merged:
         labels = [i['roiLabel']
                   for i in record[new_project_key]['workerAnnotations']]
-        print(labels)
         labels = [translator[i] for i in labels]
         majority = compute_majority(labels, exact_len=exact_nlabels)
         record[new_project_key]['majorityLabel'] = majority

--- a/slapp/utils/merge_utils.py
+++ b/slapp/utils/merge_utils.py
@@ -1,4 +1,4 @@
-from typing import List, Union, Optional, TypedDict
+from typing import List, Union, Optional, TypedDict, Any
 from pathlib import Path
 import copy
 import jsonlines
@@ -27,8 +27,21 @@ class RecordProject(TypedDict):
     workerAnnotations: List[WorkerAnnotation]
 
 
-def compute_majority(labels):
-    """return majority labels or None if tied
+def compute_majority(labels: list) -> Union[Any, None]:
+    """most prevalent of three labels or None if not 3
+
+    Parameters
+    ----------
+    labels: list
+        items could be for example "cell"/"not cell" or 1/0
+        our SagemakerGroundTruth jobs are using the strings
+
+    Returns
+    -------
+    majority:
+       element of labels that is most prevalent or None if
+       lenght of labels is not 3
+
     """
     ulabels = set(labels)
     if len(ulabels) not in [1, 2]:
@@ -47,8 +60,19 @@ def compute_majority(labels):
     return majority
 
 
-def get_record_project_key(record: dict):
-    """performs minimal validation on a record so that it can be merged
+def get_record_project_key(record: dict) -> Union[str, None]:
+    """returns the key name for the project, performs some validation
+
+    Parameters
+    ----------
+    record: dict
+        the dictionary provided
+
+    Returns
+    -------
+    project_key: str
+       the key containing the project sub-dict or None if validation fails
+
     """
     # check that is identified
     if 'roi-id' not in record:
@@ -76,6 +100,20 @@ def merge_record_projects(project1: RecordProject,
                           project2: RecordProject) -> RecordProject:
     """merges worker annotations between 2 record project entries and updates
     majorityLabel
+
+    Parameters
+    ----------
+    project1: RecordProject
+        first project to merge
+    project2: RecordProject
+        second project to merge
+
+    Returns
+    -------
+    new_project: RecordProject
+        new with workerAnnotations concatenated and sourceData appended
+        if different. Any other entities inherited from project1
+
     """
     new_project = RecordProject(copy.deepcopy(project1))
     new_project['workerAnnotations'].extend(project2['workerAnnotations'])
@@ -87,6 +125,20 @@ def merge_record_projects(project1: RecordProject,
 def merge_records(record1: dict, record2: dict) -> dict:
     """merge 2 records, maintaining project and job key names from
     record1
+
+    Parameters
+    ----------
+    record1: dict
+        first record to merge
+    record2: dict
+        second record to merge
+
+    Returns
+    -------
+    new_record: dict
+        merged record. new_record['Project'] is merged. Everything else
+        inherits from record1.
+
     """
     new_record = copy.deepcopy(record1)
 

--- a/slapp/utils/merge_utils.py
+++ b/slapp/utils/merge_utils.py
@@ -29,7 +29,8 @@ class Project(TypedDict):
 
 
 def get_project_key(record: dict) -> Union[str, None]:
-    """returns the key name for the project, performs some validation
+    """returns the key name for the project, performs some validation.
+    See Notes.
 
     Parameters
     ----------
@@ -40,6 +41,12 @@ def get_project_key(record: dict) -> Union[str, None]:
     -------
     project_key: str
        the key containing the project sub-dict or None if validation fails
+
+    Notes
+    -----
+    SagemakerGroundTruth returns a dictionary where 2 keys "<project>" and
+    "<project>-metadata" are dynamically named by the name of the launched
+    labeling job.
 
     """
     # check that is identified

--- a/slapp/utils/merge_utils.py
+++ b/slapp/utils/merge_utils.py
@@ -85,7 +85,7 @@ def merge_projects(project1: Project, project2: Project) -> Project:
     new_project = Project(copy.deepcopy(project1))
     new_project['workerAnnotations'].extend(project2['workerAnnotations'])
     if new_project['sourceData'] != project2['sourceData']:
-        new_project['sourceData'] += ' ' + project2['sourceData']
+        new_project['sourceData'] += ',' + project2['sourceData']
     return new_project
 
 

--- a/slapp/utils/merge_utils.py
+++ b/slapp/utils/merge_utils.py
@@ -90,7 +90,9 @@ def merge_projects(project1: Project, project2: Project) -> Project:
 
     """
     new_project = Project(copy.deepcopy(project1))
-    new_project['workerAnnotations'].extend(project2['workerAnnotations'])
+    for annotation in project2['workerAnnotations']:
+        if annotation not in new_project['workerAnnotations']:
+            new_project['workerAnnotations'].append(annotation)
     if new_project['sourceData'] != project2['sourceData']:
         new_project['sourceData'] += ',' + project2['sourceData']
     return new_project

--- a/slapp/utils/merge_utils.py
+++ b/slapp/utils/merge_utils.py
@@ -1,0 +1,186 @@
+from typing import List, Union, Optional, TypedDict
+from pathlib import Path
+import copy
+import jsonlines
+import boto3
+from urllib.parse import urlparse
+import tempfile
+import shutil
+import logging
+import json
+
+from slapp.transfers.utils import read_jsonlines
+
+
+class MergingException(Exception):
+    pass
+
+
+class WorkerAnnotation(TypedDict):
+    workerId: str
+    roiLabel: str
+
+
+class RecordProject(TypedDict):
+    sourceData: str
+    majorityLabel: str
+    workerAnnotations: List[WorkerAnnotation]
+
+
+def compute_majority(labels):
+    """return majority labels or None if tied
+    """
+    ulabels = set(labels)
+    if len(ulabels) not in [1, 2]:
+        raise ValueError("`compute_majority()` expects binary classification "
+                         f"but received {len(ulabels)} labels: {ulabels}")
+    counts = {ulabel: labels.count(ulabel) for ulabel in ulabels}
+
+    majority = None
+
+    # require 3 and only 3 annotations
+    if sum(counts.values()) == 3:
+        mcount = max(counts.values())
+        r_counts = {v: k for k, v in counts.items()}
+        majority = r_counts[mcount]
+
+    return majority
+
+
+def get_record_project_key(record: dict):
+    """performs minimal validation on a record so that it can be merged
+    """
+    # check that is identified
+    if 'roi-id' not in record:
+        raise MergingException("record does not contain key 'roi-id'")
+
+    # check that it conforms to
+    # https://docs.aws.amazon.com/sagemaker/latest/dg/sms-data-output.html
+    candidates = [k for k in record.keys() if '-metadata' in k]
+    if len(candidates) != 1:
+        raise MergingException(f"Record for roi-id {record['roi-id']} has "
+                               f"{len(candidates)} keys containing "
+                               "'-metadata' expecting 1 and only 1")
+
+    meta_key = candidates[0]
+    project_key = meta_key.replace("-metadata", "")
+
+    # check that there is a project entry related to the metadata
+    if project_key not in record:
+        project_key = None
+
+    return project_key
+
+
+def merge_record_projects(project1: RecordProject,
+                          project2: RecordProject) -> RecordProject:
+    """merges worker annotations between 2 record project entries and updates
+    majorityLabel
+    """
+    new_project = RecordProject(copy.deepcopy(project1))
+    new_project['workerAnnotations'].extend(project2['workerAnnotations'])
+    if new_project['sourceData'] != project2['sourceData']:
+        new_project['sourceData'] += ' ' + project2['sourceData']
+    return new_project
+
+
+def merge_records(record1: dict, record2: dict) -> dict:
+    """merge 2 records, maintaining project and job key names from
+    record1
+    """
+    new_record = copy.deepcopy(record1)
+
+    # merge the annotations
+    pk1 = get_record_project_key(record1)
+    pk2 = get_record_project_key(record2)
+    new_project = merge_record_projects(record1[pk1], record2[pk2])
+    new_record[pk1] = new_project
+
+    return new_record
+
+
+def merge_outputs(src_uris: List[Union[str, Path]],
+                  dst_uri: Optional[Union[str, Path]] = None,
+                  new_project_key: Optional[str] = "merged-project",
+                  new_job_name: Optional[str] = "merged-job") -> dict:
+    """merge outputs from multiple labeling jobs
+
+    Parameters
+    ----------
+    src_uris: list of s3 uris or local filepaths
+        source labeling job outputs to merge
+    dst_uri: s3 uri or local filepath
+        destination uri. If none (default), not written.
+
+    Returns
+    -------
+    merged: list of records
+
+    """
+
+    # merge all the records
+    htable = {}
+    nskipped = {}
+    nused = {}
+    for src_uri in src_uris:
+        reader = read_jsonlines(src_uri)
+        nskipped[str(src_uri)] = 0
+        nused[str(src_uri)] = 0
+        for record in reader:
+            # some light validation on every record
+            pkey = get_record_project_key(record)
+            if pkey is None:
+                nskipped[str(src_uri)] += 1
+                continue
+            else:
+                nused[str(src_uri)] += 1
+
+            # if already in the hash table, merge
+            if record['roi-id'] in htable:
+                record = merge_records(htable[record['roi-id']], record)
+
+            # homogenize key names across the output
+            pkey = get_record_project_key(record)
+            record[new_project_key] = record.pop(pkey)
+            mkey = pkey + '-metadata'
+            new_meta_key = new_project_key + '-metadata'
+            record[new_meta_key] = record.pop(mkey)
+            record[new_meta_key]['job-name'] = new_job_name
+
+            # set the hash value
+            htable[record['roi-id']] = record
+
+    merged = list(htable.values())
+
+    if max(nskipped.values()) > 0:
+        logging.warning("skipped some records "
+                        f"{json.dumps(nskipped, indent=2)}")
+    logging.info(f"n records used: {json.dumps(nused, indent=2)}")
+
+    # set the majority label
+    nvalid = 0
+    for record in merged:
+        labels = [i['roiLabel']
+                  for i in record[new_project_key]['workerAnnotations']]
+        majority = compute_majority(labels)
+        record[new_project_key]['majorityLabel'] = majority
+        if majority is not None:
+            nvalid += 1
+
+    if dst_uri is not None:
+        with tempfile.NamedTemporaryFile() as tmpout:
+            with open(tmpout.name, "w") as fp:
+                jsonlines.Writer(fp).write_all(merged)
+
+            if str(dst_uri).startswith("s3://"):
+                s3 = boto3.client("s3")
+                parsed_s3 = urlparse(dst_uri)
+                bucket = parsed_s3.netloc
+                file_key = parsed_s3.path[1:]
+                s3.upload_file(tmpout.name, bucket, file_key)
+            else:
+                shutil.copyfile(tmpout.name, dst_uri)
+        logging.info(f"wrote {dst_uri} with {len(merged)} records "
+                     f"and {nvalid} valid majorities.")
+
+    return merged

--- a/tests/transfers/test_transfer_utils.py
+++ b/tests/transfers/test_transfer_utils.py
@@ -3,6 +3,7 @@ import pytest
 import slapp.transfers.utils as utils
 import json
 import boto3
+from botocore.exceptions import ClientError
 from moto import mock_s3
 import pathlib
 import numpy as np
@@ -20,6 +21,15 @@ def test_s3_get_object():
     # Run the test
     response = utils.s3_get_object("s3://mybucket/my/file.json")
     assert body == response["Body"].read()
+
+
+@mock_s3
+def test_s3_get_object_failure():
+    s3 = boto3.client("s3")
+    s3.create_bucket(Bucket="mybucket")
+
+    with pytest.raises(ClientError):
+        utils.s3_get_object("s3://mybucket/does/not/exist")
 
 
 @pytest.mark.parametrize(

--- a/tests/transfers/test_transfer_utils.py
+++ b/tests/transfers/test_transfer_utils.py
@@ -9,6 +9,58 @@ import numpy as np
 import string
 
 
+@mock_s3
+def test_s3_get_object():
+    # Set up the fake bucket and object
+    s3 = boto3.client("s3")
+    s3.create_bucket(Bucket="mybucket")
+    body = b'{"a": 1}\n{"b": 2}'
+    s3.put_object(Bucket="mybucket", Key="my/file.json",
+                  Body=body)
+    # Run the test
+    response = utils.s3_get_object("s3://mybucket/my/file.json")
+    assert body == response["Body"].read()
+
+
+@pytest.mark.parametrize(
+    "body, expected",
+    [
+        (b'{"a": 1, "b": 3}\n{"b": 2}', [{"a": 1, "b": 3}, {"b": 2}]),
+        (b'{"a": 1}', [{"a": 1}]),
+        (b'', []),
+    ]
+)
+def test_read_jsonlines_file(tmp_path, body, expected):
+    with open(tmp_path / "filename", "wb") as f:
+        f.write(body)
+    reader = utils.read_jsonlines(tmp_path / "filename")
+    response = []
+    for record in reader:
+        response.append(record)
+    assert expected == response
+
+
+@mock_s3
+@pytest.mark.parametrize(
+    "body, expected",
+    [
+        (b'{"a": 1, "b": 3}\n{"b": 2}', [{"a": 1, "b": 3}, {"b": 2}]),
+        (b'{"a": 1}', [{"a": 1}]),
+        (b'', []),
+    ]
+)
+def test_read_jsonlines_s3(body, expected):
+    s3 = boto3.client("s3")
+    s3.create_bucket(Bucket="mybucket")
+    s3.put_object(Bucket="mybucket", Key="my/file.json",
+                  Body=body)
+    reader = utils.read_jsonlines("s3://mybucket/my/file.json")
+    response = []
+    for record in reader:
+        response.append(record)
+    assert expected == response
+
+
 @pytest.fixture(scope='module')
 def local_file(tmpdir_factory):
     fn = tmpdir_factory.mktemp("files").join("test.txt")

--- a/tests/utils/test_merge_utils.py
+++ b/tests/utils/test_merge_utils.py
@@ -65,7 +65,7 @@ def test_get_project_key(record, expected):
                             }]
                         },
                 {
-                    'sourceData': 's3URI1 s3URI2',
+                    'sourceData': 's3URI1,s3URI2',
                     'majorityLabel': 'cell',  # just inherits from 1st one
                     'workerAnnotations': [
                         {

--- a/tests/utils/test_merge_utils.py
+++ b/tests/utils/test_merge_utils.py
@@ -43,9 +43,9 @@ def test_compute_majority_error():
                 },
                 r".*'-metadata' expecting 1 and only 1"),
                 ])
-def test_get_record_project_key_exceptions(record, exception_match):
+def test_get_project_key_exceptions(record, exception_match):
     with pytest.raises(mu.MergingException, match=exception_match):
-        mu.get_record_project_key(record)
+        mu.get_project_key(record)
 
 
 @pytest.mark.parametrize(
@@ -58,12 +58,12 @@ def test_get_record_project_key_exceptions(record, exception_match):
                     'myproject': 'stuff'
                 },
                 "myproject")])
-def test_get_record_project_key(record, expected):
-    assert mu.get_record_project_key(record) == expected
+def test_get_project_key(record, expected):
+    assert mu.get_project_key(record) == expected
 
 
 @pytest.mark.parametrize(
-        "record_project1, record_project2, expected",
+        "project1, project2, expected",
         [
             (
                 {
@@ -105,21 +105,20 @@ def test_get_record_project_key(record, expected):
                             "roiLabel": "not cell"
                             }]
                         })])
-def test_merge_record(record_project1, record_project2, expected):
+def test_merge_record(project1, project2, expected):
     """keeping this file short and testing 2 functions at
     once with the same parameters
     """
-    assert expected == mu.merge_record_projects(record_project1,
-                                                record_project2)
+    assert expected == mu.merge_projects(project1, project2)
 
     record1 = {
             'roi-id': 1234,
-            'project1': record_project1,
+            'project1': project1,
             'project1-metadata': {'job-name': 'job1'}
             }
     record2 = {
             'roi-id': 1234,
-            'project2': record_project2,
+            'project2': project2,
             'project2-metadata': {'job-name': 'job2'}
             }
     expected_record = {
@@ -178,7 +177,7 @@ def two_jobs(tmpdir_factory):
         if len(annotations1) != 0:
             record1 = {
                 'roi-id': irecord,
-                'myproject': mu.RecordProject(
+                'myproject': mu.Project(
                     sourceData='123',
                     majorityLabel=job1_majority[irecord],
                     workerAnnotations=annotations1),
@@ -189,7 +188,7 @@ def two_jobs(tmpdir_factory):
         if len(annotations2) != 0:
             record2 = {
                 'roi-id': irecord,
-                'myproject': mu.RecordProject(
+                'myproject': mu.Project(
                     sourceData='123',
                     majorityLabel=job2_majority[irecord],
                     workerAnnotations=annotations2),
@@ -199,7 +198,7 @@ def two_jobs(tmpdir_factory):
 
         expected_job.append({
             'roi-id': irecord,
-            'merged-project': mu.RecordProject(
+            'merged-project': mu.Project(
                 sourceData='123',
                 majorityLabel=expected_majority[irecord],
                 workerAnnotations=expected_annotations),

--- a/tests/utils/test_merge_utils.py
+++ b/tests/utils/test_merge_utils.py
@@ -1,0 +1,286 @@
+import pytest
+import jsonlines
+import boto3
+from moto import mock_s3
+
+import slapp.utils.merge_utils as mu
+
+
+@pytest.mark.parametrize(
+        "labels, expected",
+        [
+            # not 3 annotations
+            ([0, 0, 0, 1, 1], None),
+            # 3 annotations
+            ([0, 0, 1], 0),
+            ([0, 1, 1], 1),
+            # works with strings
+            (['a', 'b', 'a'], 'a'),
+            (['a', 'b', 'b'], 'b'),
+            # works with unanimity
+            (['a', 'a', 'a'], 'a')])
+def test_compute_majority(labels, expected):
+    majority = mu.compute_majority(labels)
+    assert majority == expected
+
+
+def test_compute_majority_error():
+    with pytest.raises(ValueError,
+                       match=r".*expects binary classification.*"):
+        mu.compute_majority(['a', 'b', 'c'])
+
+
+@pytest.mark.parametrize(
+        "record, exception_match",
+        [
+            # need an roi-id key
+            ({'a': 1, 'b': 2}, r"record does not contain key 'roi-id'"),
+            # need 1 and only 1 key matching *-metadata
+            ({
+                'roi-id': 123,
+                'x-metadata': {'xmeta': 'stuff'},
+                'y-metadata': {'ymeta': 'stuff'}
+                },
+                r".*'-metadata' expecting 1 and only 1"),
+                ])
+def test_get_record_project_key_exceptions(record, exception_match):
+    with pytest.raises(mu.MergingException, match=exception_match):
+        mu.get_record_project_key(record)
+
+
+@pytest.mark.parametrize(
+        "record, expected",
+        [
+            (
+                {
+                    'roi-id': 123,
+                    'myproject-metadata': 'metastuff',
+                    'myproject': 'stuff'
+                },
+                "myproject")])
+def test_get_record_project_key(record, expected):
+    assert mu.get_record_project_key(record) == expected
+
+
+@pytest.mark.parametrize(
+        "record_project1, record_project2, expected",
+        [
+            (
+                {
+                    'sourceData': 's3URI1',
+                    'majorityLabel': 'cell',
+                    'workerAnnotations': [
+                        {
+                            "workerId": "idA1",
+                            "roiLabel": "cell"
+                            }]
+                        },
+                {
+                    'sourceData': 's3URI2',
+                    'majorityLabel': 'not cell',
+                    'workerAnnotations': [
+                        {
+                            "workerId": "idA2",
+                            "roiLabel": "not cell"
+                            },
+                        {
+                            "workerId": "idA3",
+                            "roiLabel": "not cell"
+                            }]
+                        },
+                {
+                    'sourceData': 's3URI1 s3URI2',
+                    'majorityLabel': 'cell',  # just inherits from 1st one
+                    'workerAnnotations': [
+                        {
+                            "workerId": "idA1",
+                            "roiLabel": "cell"
+                            },
+                        {
+                            "workerId": "idA2",
+                            "roiLabel": "not cell"
+                            },
+                        {
+                            "workerId": "idA3",
+                            "roiLabel": "not cell"
+                            }]
+                        })])
+def test_merge_record(record_project1, record_project2, expected):
+    """keeping this file short and testing 2 functions at
+    once with the same parameters
+    """
+    assert expected == mu.merge_record_projects(record_project1,
+                                                record_project2)
+
+    record1 = {
+            'roi-id': 1234,
+            'project1': record_project1,
+            'project1-metadata': {'job-name': 'job1'}
+            }
+    record2 = {
+            'roi-id': 1234,
+            'project2': record_project2,
+            'project2-metadata': {'job-name': 'job2'}
+            }
+    expected_record = {
+            'roi-id': 1234,
+            'project1': expected,
+            'project1-metadata': {'job-name': 'job1'}
+            }
+    new_record = mu.merge_records(record1, record2)
+    assert new_record == expected_record
+
+
+@pytest.fixture(scope='module')
+def two_jobs(tmpdir_factory):
+    """makes a list of jsons representative of 2 jobs
+       labels are [0, 1]
+    """
+    x = -1  # easier to read tables below, indicates no label from worker
+    workers_job1 = [
+            [0, 1, x, 0, 1, x, 0, 1],
+            [1, x, 0, 1, x, 0, 1, 1],
+            [0, 0, 1, x, 1, 1, 0, 1]]
+    job1_majority = \
+            [0, x, x, x, x, x, 0, 1]  # noqa
+    workers_job2 = [
+            [x, x, 0, x, x, 1, x, x],
+            [x, 1, x, x, 1, x, x, x],
+            [x, x, x, 0, x, x, x, x]]
+    job2_majority = \
+            [x, x, x, x, x, x, x, x]  # noqa
+    expected = [
+            [0, 1, 0, 0, 1, 1, 0, 1],
+            [1, 1, 0, 1, 1, 0, 1, 1],
+            [0, 0, 1, 0, 1, 1, 0, 1]]
+    expected_majority = \
+            [0, 1, 0, 0, 1, 1, 0, 1]  # noqa
+
+    job1 = []
+    job2 = []
+    expected_job = []
+    for irecord in range(8):
+        annotations1 = []
+        annotations2 = []
+        expected_annotations = []
+        for iworker in range(3):
+            w1 = workers_job1[iworker][irecord]
+            if w1 != -1:
+                annotations1.append(
+                    mu.WorkerAnnotation(workerId=iworker, roiLabel=w1))
+            w2 = workers_job2[iworker][irecord]
+            if w2 != -1:
+                annotations2.append(
+                    mu.WorkerAnnotation(workerId=iworker, roiLabel=w2))
+            expected_annotations.append(
+                   mu.WorkerAnnotation(workerId=iworker,
+                                       roiLabel=expected[iworker][irecord]))
+        if len(annotations1) != 0:
+            record1 = {
+                'roi-id': irecord,
+                'myproject': mu.RecordProject(
+                    sourceData='123',
+                    majorityLabel=job1_majority[irecord],
+                    workerAnnotations=annotations1),
+                'myproject-metadata': {'job-name': 'job1'}
+                }
+            job1.append(record1)
+
+        if len(annotations2) != 0:
+            record2 = {
+                'roi-id': irecord,
+                'myproject': mu.RecordProject(
+                    sourceData='123',
+                    majorityLabel=job2_majority[irecord],
+                    workerAnnotations=annotations2),
+                'myproject-metadata': {'job-name': 'job2'}
+                }
+            job2.append(record2)
+
+        expected_job.append({
+            'roi-id': irecord,
+            'merged-project': mu.RecordProject(
+                sourceData='123',
+                majorityLabel=expected_majority[irecord],
+                workerAnnotations=expected_annotations),
+            'merged-project-metadata': {'job-name': 'merged-job'}})
+
+    tdir = tmpdir_factory.mktemp('job_outputs')
+    jpath1 = tdir / "manifest1.jsonl"
+    with open(jpath1, "w") as fp:
+        w = jsonlines.Writer(fp)
+        w.write_all(job1)
+
+    jpath2 = tdir / "manifest2.jsonl"
+    with open(jpath2, "w") as fp:
+        w = jsonlines.Writer(fp)
+        w.write_all(job2)
+
+    yield jpath1, jpath2, expected_job
+
+
+def test_merge_outputs(two_jobs):
+    """tests that the merge merges as expected. Output not sent to disk or bucket
+    """
+    jpath1, jpath2, expected = two_jobs
+
+    merged = mu.merge_outputs(src_uris=[jpath1, jpath2])
+
+    assert len(merged) == len(expected)
+
+    # sort into order
+    ids = [i['roi-id'] for i in merged]
+    merged = [i for _, i in sorted(zip(ids, merged))]
+    ids = [i['roi-id'] for i in expected]
+    expected = [i for _, i in sorted(zip(ids, expected))]
+
+    for i, (m, e) in enumerate(zip(merged, expected)):
+        assert m.keys() == e.keys()
+        for k in ['roi-id', 'merged-project-metadata']:
+            assert m[k] == e[k]
+        for k in ['sourceData', 'majorityLabel']:
+            assert m['merged-project'][k] == e['merged-project'][k]
+
+        # sort the labels by worker ids to align for comparison
+        mwa = m['merged-project']['workerAnnotations']
+        ids = [i['workerId'] for i in mwa]
+        mlabels = [imwa['roiLabel'] for _, imwa in sorted(zip(ids, mwa))]
+
+        ewa = e['merged-project']['workerAnnotations']
+        ids = [i['workerId'] for i in ewa]
+        elabels = [imwa['roiLabel'] for _, imwa in sorted(zip(ids, ewa))]
+
+        assert mlabels == elabels
+
+
+@mock_s3
+@pytest.mark.parametrize("src_type", ["s3", "local"])
+@pytest.mark.parametrize("dst_type", ["s3", "local"])
+def test_merge_outputs_dst(two_jobs, src_type, dst_type, tmp_path):
+    """check that the function can r/w with local or s3
+    """
+    jpath1, jpath2, expected = two_jobs
+
+    bucket = "mybucket"
+
+    if (dst_type == "s3") | (src_type == "s3"):
+        s3 = boto3.client("s3")
+        s3.create_bucket(Bucket=bucket)
+
+    if src_type == "s3":
+        s3.upload_file(str(jpath1), bucket, "job1.jsonl")
+        jpath1 = f"s3://{bucket}/job1.jsonl"
+        s3.upload_file(str(jpath2), bucket, "job2.jsonl")
+        jpath2 = f"s3://{bucket}/job2.jsonl"
+
+    if dst_type == "s3":
+        dst_uri = f"s3://{bucket}/output.jsonl"
+    else:
+        dst_uri = tmp_path / "output.jsonl"
+
+    merged = mu.merge_outputs(src_uris=[jpath1, jpath2], dst_uri=dst_uri)
+    assert len(merged) == len(expected)
+
+    # exists with content? separate test checks merging
+    dst = list(mu.read_jsonlines(dst_uri))
+    assert len(dst) == len(expected)

--- a/tests/utils/test_merge_utils.py
+++ b/tests/utils/test_merge_utils.py
@@ -46,10 +46,16 @@ def test_get_project_key(record, expected):
                     'sourceData': 's3URI1',
                     'majorityLabel': 'cell',
                     'workerAnnotations': [
+                        # repeat will not be duplicated
                         {
                             "workerId": "idA1",
                             "roiLabel": "cell"
-                            }]
+                            },
+                        {
+                            "workerId": "idA2",
+                            "roiLabel": "not cell"
+                            },
+                        ]
                         },
                 {
                     'sourceData': 's3URI2',


### PR DESCRIPTION
### Overview
Adds utility functions to merge multiple SagemakerGroundTruth output manifests into 1 manifest. This does not have a CLI, as it is expected to be used during data-science mode to prepare some classifier inputs. An example of doing that is provided in this description. This is the machinery for #25, and this PR demonstrates that it is ready as soon as the annotators are done.

### Validation
The following call retrieves 2 output manifests from S3 and merges them (the code in this PR) and then talks to on-prem databases to assemble the training data (not part of this PR, uses DB connections from this repo). The code for this file is included here, collapsed, as a starting point example for the next dev starting to cook up a jupyter notebook or something.
<details>
  <summary>example_merge_and_prepare.py</summary>

```python
import logging
import json
import numpy as np

import slapp.utils.merge_utils as mu
from slapp.utils import query_utils
from slapp.rois import ROI

logging.getLogger().setLevel(logging.INFO)


def meta_from_experiment_id(experiment_id, db_connection):
    meta_data = db_connection.query(
        "SELECT e.name AS rig, i.depth, st.acronym AS targeted_structure, "
        "d.full_genotype FROM ophys_experiments oe "
        "JOIN ophys_sessions os ON oe.ophys_session_id=os.id "
        "JOIN equipment e ON e.id=os.equipment_id "
        "JOIN specimens sp ON sp.id=os.specimen_id "
        "JOIN imaging_depths i ON i.id=oe.imaging_depth_id "
        "JOIN structures st ON st.id=oe.targeted_structure_id "
        "JOIN donors d ON d.id=sp.donor_id "
        f"WHERE oe.id = {experiment_id}")

    if len(meta_data) != 1:
        raise ValueError(f"expected 1 record for {experiment_id}, "
                         f"found {len(meta_data)}")

    return meta_data[0]


# merge some output manifests together
src_uris = [
        "s3://prod.slapp.alleninstitute.org/2-line 2-project/20200520051838/2-line-2-project-prod-v2-output/2-line-2-project-prod-v2/manifests/output/output.manifest",
        "s3://prod.slapp.alleninstitute.org/2-line 2-project/20200520051838/2-line-2-project-output/2-line-2-project-prod/manifests/output/output.manifest"]

dst_uri = "/home/danielk/sgt_merged_manifest.jsonl"

_ = mu.merge_outputs(src_uris, dst_uri)

# select only the valid ones
x = list(mu.read_jsonlines(dst_uri))
valid = [i for i in x if i['merged-project']['majorityLabel'] is not None]

# retrieve the data necessary for input to
label_credentials = query_utils.get_db_credentials(
        env_prefix="LABELING_",
        **query_utils.label_defaults)
label_connection = query_utils.DbConnection(**label_credentials)
lims_credentials = query_utils.get_db_credentials(
        env_prefix="LIMS_",
        **query_utils.lims_defaults)
lims_connection = query_utils.DbConnection(**lims_credentials)

rois = []
data = []
translator = {'cell': 1, 'not cell': 0}
for record in valid:
    roi = ROI.roi_from_query(record['roi-id'], label_connection)
    meta = meta_from_experiment_id(record['experiment-id'], lims_connection)
    entry = {
            "roi_id": roi.roi_id,
            "coo_cols": roi._sparse_coo.col.tolist(),
            "coo_rows": roi._sparse_coo.row.tolist(),
            "coo_data": roi._sparse_coo.data.tolist(),
            "image_shape": roi.image_shape,
            "trace": roi.trace
            }
    entry.update(meta)
    entry.update(
            {"label": translator[record['merged-project']['majorityLabel']]})
    data.append(entry)


# train test split (scikit-learn not a dependency of slapp)
def train_test_split(data, test_size, random_state=0):
    ntest = int(test_size * len(data))
    rng = np.random.default_rng(random_state)
    rng.shuffle(data)
    return data[ntest:], data[:ntest]


train, test = train_test_split(data, test_size=0.3, random_state=0)

training_path = "/home/danielk/mlflow_example/training_data.json"
with open(training_path, "w") as f:
    json.dump(train, f)
testing_path = "/home/danielk/mlflow_example/testing_data.json"
with open(testing_path, "w") as f:
    json.dump(test, f)
print(f"wrote {training_path}")
print(f"wrote {testing_path}")

```

</details>

```
$ python example_merge_and_prepare.py
WARNING:root:skipped some records {
  "s3://prod.slapp.alleninstitute.org/2-line 2-project/20200520051838/2-line-2-project-prod-v2-output/2-line-2-project-prod-v2/manifests/output/output.manifest": 392,
  "s3://prod.slapp.alleninstitute.org/2-line 2-project/20200520051838/2-line-2-project-output/2-line-2-project-prod/manifests/output/output.manifest": 765
}
INFO:root:n records used: {
  "s3://prod.slapp.alleninstitute.org/2-line 2-project/20200520051838/2-line-2-project-prod-v2-output/2-line-2-project-prod-v2/manifests/output/output.manifest": 608,
  "s3://prod.slapp.alleninstitute.org/2-line 2-project/20200520051838/2-line-2-project-output/2-line-2-project-prod/manifests/output/output.manifest": 235
}
INFO:root:wrote /home/danielk/sgt_merged_manifest.jsonl with 694 records and 198 valid majorities.
wrote /home/danielk/mlflow_example/training_data.json
wrote /home/danielk/mlflow_example/testing_data.json
```
The inputs for training have now been created. 
Then, following the [automated mlflow CLI test](https://github.com/AllenInstitute/croissant/blob/01f580bfb80a411f47bf285ff29b0620548b2dcb/.circleci/config.yml#L57-L71) as an example.
```
export MLFLOW_TRACKING_URI=/home/danielk/mlflow_example/tracking
export ARTIFACT_URI=/home/danielk/mlflow_example/artifacts
export MYEXPERIMENT=my_experiment
mlflow experiments create \
              --experiment-name ${MYEXPERIMENT} \
              --artifact-location ${ARTIFACT_URI}
```
The mlflow run command is being run from the `croissant` repo root dir to pass in the `MLProject` file.
```
~/croissant$ mlflow run . --backend local --experiment-name ${MYEXPERIMENT} -P training_data=/home/danielk/mlflow_example/training_data.json -P test_data=/home/danielk/mlflow_example/testing_data.json -P scoring="['roc_auc']" -P refit=roc_auc -P log_level=INFO

2020/07/09 15:57:59 INFO mlflow.projects: === Created directory /tmp/tmps19ei_lc for downloading remote URIs passed to arguments of type 'path' ===
2020/07/09 15:57:59 INFO mlflow.projects: === Running command 'source /home/danielk/miniconda3/bin/../etc/profile.d/conda.sh && conda activate mlflow-ead6525c1aa4af043de9afdf421d4abe083b57fe 1>&2 && python -m croissant.train --training_data /home/danielk/mlflow_example/training_data.json --test_data /home/danielk/mlflow_example/testing_data.json --scoring '['"'"'roc_auc'"'"']' --refit roc_auc --log_level INFO' in run with ID '5f5b74552cea4e08b626012146bb1ad3' === 
INFO:TrainClassifier:Reading training data and extracting features.
INFO:TrainClassifier:Fitting model to data!
INFO:TrainClassifier:fitting model with **<snipped>**
**<snipped convergence warnings>**
INFO:ClassifierTrainer:Model fit, with best score 0.6386397707231041 and best parameters {'model__l1_ratio': 0.25}.
/home/danielk/miniconda3/envs/mlflow-ead6525c1aa4af043de9afdf421d4abe083b57fe/lib/python3.8/site-packages/joblib/numpy_pickle.py:103: DeprecationWarning: tostring() is deprecated. Use tobytes() instead.
  pickler.file_handle.write(chunk.tostring('C'))
INFO:ClassifierTrainer:logged training to mlflow run 5f5b74552cea4e08b626012146bb1ad3
2020/07/09 15:58:05 INFO mlflow.projects: === Run (ID '5f5b74552cea4e08b626012146bb1ad3') succeeded ===

```
which has written a model:
```
$ ls /home/danielk/mlflow_example/artifacts/5f5b74552cea4e08b626012146bb1ad3/artifacts/
trained_model.joblib
```
and we can also confirm this through the mlflow ui:
```
$ mlflow ui --backend-store-uri /home/danielk/mlflow_example/tracking
```
![image](https://user-images.githubusercontent.com/32312979/87100236-b626b500-c200-11ea-8f48-47b71ba8d526.png)