### PR TITLE
Add ability to run SLAPP transform_pipeline on production data

### DIFF
--- a/slapp/transfers/utils.py
+++ b/slapp/transfers/utils.py
@@ -3,13 +3,19 @@ import botocore.config
 from botocore.exceptions import ClientError
 import pathlib
 import jsonlines
-from typing import Union, List, TypedDict, Tuple, Generator
+from typing import Union, List, Tuple, Generator
 import hashlib
 import base64
 import numpy as np
 import boto3
 from urllib.parse import urlparse
 import logging
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 
 def s3_get_object(uri: str) -> dict:

--- a/slapp/utils/merge_utils.py
+++ b/slapp/utils/merge_utils.py
@@ -1,4 +1,4 @@
-from typing import List, Union, Optional, TypedDict
+from typing import List, Union, Optional
 from pathlib import Path
 import copy
 import jsonlines
@@ -8,9 +8,15 @@ import tempfile
 import shutil
 import logging
 import json
+import sys
 
 from slapp.transfers.utils import read_jsonlines
 from slapp.lambdas.post_annotation import compute_majority
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
 
 
 class MergingException(Exception):

--- a/tests/test_rois.py
+++ b/tests/test_rois.py
@@ -261,3 +261,49 @@ def test_roi_generate_outline(weighted, full, expected, athresh, quantile):
             absolute_threshold=athresh,
             quantile=quantile)
     assert np.all(outline == expected)
+
+
+@pytest.mark.parametrize(
+        "mask_matrix, xoff, yoff, shape, expected",
+        [
+            (
+                [[True, False, True, False],
+                 [False, True, True, False],
+                 [False, True, True, False],
+                 [False, True, True, False]],
+                0, 0, None,
+                [[True, False, True],
+                 [False, True, True],
+                 [False, True, True],
+                 [False, True, True]]
+                ),
+            (
+                [[True, False, True, False],
+                 [False, True, True, False],
+                 [False, True, True, False],
+                 [False, True, True, False]],
+                0, 0, (6, 5),
+                [[True, False, True, False, False],
+                 [False, True, True, False, False],
+                 [False, True, True, False, False],
+                 [False, True, True, False, False],
+                 [False, False, False, False, False],
+                 [False, False, False, False, False]]
+                ),
+            (
+                [[True, False, True, False],
+                 [False, True, True, False],
+                 [False, True, True, False],
+                 [False, True, True, False]],
+                2, 1, (6, 5),
+                [[False, False, False, False, False],
+                 [False, False, True, False, True],
+                 [False, False, False, True, True],
+                 [False, False, False, True, True],
+                 [False, False, False, True, True],
+                 [False, False, False, False, False]]
+                ),
+            ])
+def test_coo_from_lims_style(mask_matrix, xoff, yoff, shape, expected):
+    coo = roi_module.coo_from_lims_style(mask_matrix, xoff, yoff, shape)
+    np.testing.assert_array_equal(coo.toarray(), np.array(expected))


### PR DESCRIPTION
- [ ] Squash commits once PR looks good

### Purpose
* Enables running transform pipeline from a file input (rather than dev postgres DB)
* Enables output of transform pipeline to a file (rather than dev postgres DB)

### Input Format
A typical example:
```
{
  "experiment_id": "1000744365",
  "local_to_global_roi_id_map": {
    "73": 2000159,
    "8": 2000255,
    "113": 2000308
  },
  "binarized_rois_path": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/binarize_output.json",
  "traces_h5_path": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/roi_traces.h5",
  "movie_path": "/allen/programs/braintv/production/visualbehavior/prod3/specimen_935565389/ophys_session_1000439105/ophys_experiment_1000744365/processed//motion_corrected_video.h5"
}
```

### Output (a slapp manifest)
```
{"experiment-id": 1000744365, "roi-id": 2000255, "source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/outline_2000255.png", "roi-mask-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/mask_2000255.png", "full-video-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/full_video.webm", "video-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/video_2000255.webm", "max-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/max_2000255.png", "avg-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/avg_2000255.png", "trace-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/trace_2000255.json", "full-outline-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/full_outline_2000255.png"}
{"experiment-id": 1000744365, "roi-id": 2000159, "source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/outline_2000159.png", "roi-mask-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/mask_2000159.png", "full-video-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/full_video.webm", "video-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/video_2000159.webm", "max-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/max_2000159.png", "avg-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/avg_2000159.png", "trace-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/trace_2000159.json", "full-outline-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/full_outline_2000159.png"}
{"experiment-id": 1000744365, "roi-id": 2000308, "source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/outline_2000308.png", "roi-mask-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/mask_2000308.png", "full-video-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/full_video.webm", "video-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/video_2000308.webm", "max-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/max_2000308.png", "avg-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/avg_2000308.png", "trace-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/trace_2000308.json", "full-outline-source-ref": "/allen/aibs/informatics/danielk/dev_LIMS/supplemental/1000744365/slapp_artifacts/20200908152036/full_outline_2000308.png"}
```