### PR TITLE
adds codecov config to warn only

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: no
+
+
+coverage:
+  status:
+    project: off
+    patch: off


### PR DESCRIPTION
stops flagging PRs with red X if codecov is not satisfied. Still comments on PR.