### PR TITLE
Transform_pipeline modifications

### DIFF
--- a/slapp/transforms/transform_pipeline.py
+++ b/slapp/transforms/transform_pipeline.py
@@ -371,15 +371,17 @@ class TransformPipeline(argschema.ArgSchemaParser):
         insert_statements = []
         manifests = []
         for roi in rois:
+            roi_id = f'{roi.experiment_id}_{roi.roi_id}'
+
             # mask and outline from ROI class
-            mask_path = output_dir / f"mask_{roi.roi_id}.png"
-            outline_path = output_dir / f"outline_{roi.roi_id}.png"
-            full_outline_path = output_dir / f"full_outline_{roi.roi_id}.png"
-            sub_video_path = output_dir / f"video_{roi.roi_id}.webm"
-            max_proj_path = output_dir / f"max_{roi.roi_id}.png"
-            avg_proj_path = output_dir / f"avg_{roi.roi_id}.png"
-            corr_proj_path = output_dir / f"corr_{roi.roi_id}.png"
-            trace_path = output_dir / f"trace_{roi.roi_id}.json"
+            mask_path = output_dir / f"mask_{roi_id}.png"
+            outline_path = output_dir / f"outline_{roi_id}.png"
+            full_outline_path = output_dir / f"full_outline_{roi_id}.png"
+            sub_video_path = output_dir / f"video_{roi_id}.webm"
+            max_proj_path = output_dir / f"max_{roi_id}.png"
+            avg_proj_path = output_dir / f"avg_{roi_id}.png"
+            corr_proj_path = output_dir / f"corr_{roi_id}.png"
+            trace_path = output_dir / f"trace_{roi_id}.json"
 
             mask = roi.generate_ROI_mask(
                     shape=self.args['cropped_shape'])

--- a/slapp/transforms/transform_pipeline.py
+++ b/slapp/transforms/transform_pipeline.py
@@ -168,6 +168,8 @@ class TransformPipelineSchema(argschema.ArgSchema):
         description=("if generating from prod manifest, makes artifacts for "
                      "all ROIs. For disk space reasons, probably only want "
                      "to do this with skip_movies=True."))
+    correlation_projection_path = argschema.fields.InputFile(
+        required=True, description='Path to correlation projection png')
 
     @mm.pre_load
     def set_segmentation_run_id(self, data, **kwargs):
@@ -238,8 +240,6 @@ class ProdSegmentationRunManifestSchema(mm.Schema):
     local_to_global_roi_id_map = mm.fields.Dict(required=False,
                                                 keys=mm.fields.Int(),
                                                 values=mm.fields.Int())
-    correlation_projection_path = argschema.fields.InputFile(
-        required=True, description='Path to correlation projection pngs')
 
     @mm.post_load
     def load_rois(self, data, **kwargs) -> dict:

--- a/slapp/transforms/transform_pipeline.py
+++ b/slapp/transforms/transform_pipeline.py
@@ -309,8 +309,7 @@ class TransformPipeline(argschema.ArgSchemaParser):
             all_ROIs=self.args['all_ROIs'],
             include_trace=not self.args['skip_traces']
         )
-        output_dir = Path(self.args['artifact_basedir']) / \
-            self.timestamp
+        output_dir = Path(self.args['artifact_basedir'])
         os.makedirs(output_dir, exist_ok=True)
 
         downsampled_video = downsample_h5_video(

--- a/slapp/transforms/transform_pipeline.py
+++ b/slapp/transforms/transform_pipeline.py
@@ -326,6 +326,7 @@ class TransformPipeline(argschema.ArgSchemaParser):
         max_projection = np.max(downsampled_video, axis=0)
         correlation_projection = plt.imread(self.args[
                                                 'correlation_projection_path'])
+        correlation_projection = correlation_projection[:, :, 0]
         movie_quantiles = [self.args['movie_lower_quantile'],
                            self.args['movie_upper_quantile']]
         proj_quantiles = [self.args['projection_lower_quantile'],


### PR DESCRIPTION
- Deprecates reading from slapp db
- makes reading from manifest default
- add correlation projection
- adds ability to skip reading traces