### PR TITLE
allow masks larger than crop size

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ pandas
 argschema==2.0.1
 jsonlines
 flake8
+imgaug

--- a/slapp/rois.py
+++ b/slapp/rois.py
@@ -6,6 +6,7 @@ import cv2
 import slapp.utils.query_utils as query_utils
 from slapp.transforms.array_utils import (
         center_pad_2d, crop_2d_array)
+import imgaug.augmenters as iaa
 
 
 def coo_from_lims_style(mask_matrix: List[List[bool]],
@@ -106,6 +107,8 @@ def sized_mask(
     if not full:
         mask = crop_2d_array(mask)
         if shape is not None:
+            mask = iaa.CenterCropToFixedSize(
+                width=shape[0], height=shape[1]).augment_image(image=mask)
             mask = center_pad_2d(mask, shape)
     return mask
 


### PR DESCRIPTION
Currently, if a mask was larger than the crop size, then it would not be padded.
This PR first center crops the mask to the crop size so that it is always <= crop size. This will cut off part of the mask if it is very large.

## Before
![before](https://user-images.githubusercontent.com/5454341/156590100-57860631-9765-48ed-85a7-114a1bb7ce06.png)

## After
![after](https://user-images.githubusercontent.com/5454341/156590134-9b5fd914-f56f-48fb-aa2c-79d20ee6b0cb.png)

